### PR TITLE
Support for external events programming model

### DIFF
--- a/backend/runtimestate.go
+++ b/backend/runtimestate.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	"github.com/microsoft/durabletask-go/api"
 	"github.com/microsoft/durabletask-go/internal/helpers"
 	"github.com/microsoft/durabletask-go/internal/protos"
-	"google.golang.org/protobuf/types/known/timestamppb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 var ErrDuplicateEvent = errors.New("duplicate event")


### PR DESCRIPTION
This PR enables support for external event handling in orchestrations written in Go. Example:

```go
r := task.NewTaskRegistry()
r.AddOrchestratorN("SampleOrchestrator", func(ctx *task.OrchestrationContext) (any, error) {
	// Wait up to 5 minutes for an event named "MyEvent" with an int data payload
	var data int
	if err := ctx.WaitForSingleEvent("MyEvent", 2*time.Second).Await(&data); err != nil {
		// Timeout expired
		return nil, err
	}
	return data, nil
})
```

Client code can send an event to this orchestration using code similar to the following:

```go
id, _ := client.ScheduleNewOrchestration(ctx, "SampleOrchestrator")
data := 42
client.RaiseEvent(ctx, id, "MyEvent", data)
```