### PR TITLE
External events sample + minor fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch Current Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}"
+        },
+        {
             "name": "Attach to Process",
             "type": "go",
             "request": "attach",
@@ -12,11 +19,12 @@
             "processId": 0
         },
         {
-            "name": "Launch Package",
+            "name": "Launch Main Package",
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${workspaceFolder}"
+            "program": "${workspaceFolder}",
+            "console": "integratedTerminal"
         }
     ]
 }

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -188,7 +188,11 @@ func (w *worker) processWorkItem(ctx context.Context, wi WorkItem) {
 	w.logger.Debugf("%v: processing work item: %s", w.Name(), wi.Description())
 
 	if err := w.processor.ProcessWorkItem(ctx, wi); err != nil {
-		w.logger.Errorf("%v: failed to process work item: %v", w.Name(), err)
+		if errors.Is(err, ctx.Err()) {
+			w.logger.Warnf("%v: abandoning work item due to cancellation", w.Name())
+		} else {
+			w.logger.Errorf("%v: failed to process work item: %v", w.Name(), err)
+		}
 		if err := w.processor.AbandonWorkItem(ctx, wi); err != nil {
 			w.logger.Errorf("%v: failed to abandon work item: %v", w.Name(), err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/marusama/semaphore/v2 v2.5.0
 	github.com/mattn/go-sqlite3 v1.14.14
 	github.com/stretchr/testify v1.8.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4
 	go.opentelemetry.io/otel v1.11.1
 	go.opentelemetry.io/otel/exporters/zipkin v1.11.1
 	go.opentelemetry.io/otel/sdk v1.11.1
@@ -26,7 +27,6 @@ require (
 	github.com/openzipkin/zipkin-go v0.4.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.36.4 // indirect
 	go.opentelemetry.io/otel/metric v0.33.0 // indirect
 	golang.org/x/net v0.0.0-20221004154528-8021a29435af // indirect
 	golang.org/x/sys v0.0.0-20221010170243-090e33056c14 // indirect

--- a/samples/externalevents.go
+++ b/samples/externalevents.go
@@ -1,0 +1,61 @@
+package samples
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/microsoft/durabletask-go/task"
+)
+
+func RunExternalEventsSample() {
+	r := task.NewTaskRegistry()
+	r.AddOrchestrator(ExternalEventOrchestrator)
+
+	ctx := context.Background()
+	client, worker := Init(ctx, r)
+	defer worker.Shutdown(ctx)
+
+	// Start the orchestration
+	id, err := client.ScheduleNewOrchestration(ctx, ExternalEventOrchestrator)
+	if err != nil {
+		panic(err)
+	}
+	metadata, err := client.WaitForOrchestrationStart(ctx, id)
+	if err != nil {
+		panic(err)
+	}
+
+	// Prompt the user for their name and send that to the orchestrator
+	go func() {
+		fmt.Println("Enter your first name: ")
+		var nameInput string
+		fmt.Scanln(&nameInput)
+		if err = client.RaiseEvent(ctx, id, "Name", nameInput); err != nil {
+			panic(err)
+		}
+	}()
+
+	// After the orchestration receives the event, it should complete on its own
+	metadata, err = client.WaitForOrchestrationCompletion(ctx, id)
+	if err != nil {
+		panic(err)
+	}
+	if metadata.FailureDetails != nil {
+		fmt.Println("orchestration failed:", metadata.FailureDetails.ErrorMessage)
+	} else {
+		fmt.Println("orchestration completed:", metadata.SerializedOutput)
+	}
+}
+
+// ExternalEventOrchestrator is an orchestrator function that blocks for 30 seconds or
+// until a "Name" event is sent to it.
+func ExternalEventOrchestrator(ctx *task.OrchestrationContext) (any, error) {
+	var nameInput string
+	if err := ctx.WaitForSingleEvent("Name", 30*time.Second).Await(&nameInput); err != nil {
+		// Timeout expired
+		return nil, err
+	}
+
+	return fmt.Sprintf("Hello, %s!", nameInput), nil
+}


### PR DESCRIPTION
As a follow-up to https://github.com/microsoft/durabletask-go/pull/3, this PR adds a new sample and a description of external event usage in the README file.

It also contains a minor logging bug fix for the worker shutdown code path, as well as fixing a warning in the go.mod file.