### PR TITLE
Suspend/resume functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The full sample can be found [here](./samples/externalevents.go).
 
 ### Managing local orchestrations
 
-The following code snippet provides an example of how you can configure and run orchestrations. The `TaskRegistry` type allows you to register orchestrator and activity functions, and the `TaskHubClient` allows you to start, query, terminate, and wait for orchestrations to complete.
+The following code snippet provides an example of how you can configure and run orchestrations. The `TaskRegistry` type allows you to register orchestrator and activity functions, and the `TaskHubClient` allows you to start, query, terminate, suspend, resume, and wait for orchestrations to complete.
 
 The code snippet below demonstrates how to register and start a new instance of the `ActivitySequenceOrchestrator` orchestrator and wait for it to complete. The initialization of the client and worker are left out for brevity.
 

--- a/api/client_grpc.go
+++ b/api/client_grpc.go
@@ -148,6 +148,32 @@ func (c *grpcClient) TerminateOrchestration(ctx context.Context, id InstanceID, 
 	return nil
 }
 
+// SuspendOrchestration suspends an orchestration instance, halting processing of its events until a "resume" operation resumes it.
+//
+// Note that suspended orchestrations are still considered to be "running" even though they will not process events.
+func (c *grpcClient) SuspendOrchestration(ctx context.Context, id InstanceID, reason string) error {
+	req := &protos.SuspendRequest{
+		InstanceId: string(id),
+		Reason:     wrapperspb.String(reason),
+	}
+	if _, err := c.client.SuspendInstance(ctx, req); err != nil {
+		return fmt.Errorf("failed to suspend orchestration: %w", err)
+	}
+	return nil
+}
+
+// ResumeOrchestration resumes an orchestration instance that was previously suspended.
+func (c *grpcClient) ResumeOrchestration(ctx context.Context, id InstanceID, reason string) error {
+	req := &protos.ResumeRequest{
+		InstanceId: string(id),
+		Reason:     wrapperspb.String(reason),
+	}
+	if _, err := c.client.ResumeInstance(ctx, req); err != nil {
+		return fmt.Errorf("failed to resume orchestration: %w", err)
+	}
+	return nil
+}
+
 func makeGetInstanceRequest(id InstanceID, opts []FetchOrchestrationMetadataOptions) *protos.GetInstanceRequest {
 	req := &protos.GetInstanceRequest{InstanceId: string(id)}
 	for _, configure := range opts {

--- a/internal/helpers/history.go
+++ b/internal/helpers/history.go
@@ -194,6 +194,38 @@ func NewSendEventEvent(eventID int32, instanceID string, name string, rawInput *
 	}
 }
 
+func NewSuspendOrchestrationEvent(reason string) *protos.HistoryEvent {
+	var input *wrapperspb.StringValue
+	if reason != "" {
+		input = wrapperspb.String(reason)
+	}
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_ExecutionSuspended{
+			ExecutionSuspended: &protos.ExecutionSuspendedEvent{
+				Input: input,
+			},
+		},
+	}
+}
+
+func NewResumeOrchestrationEvent(reason string) *protos.HistoryEvent {
+	var input *wrapperspb.StringValue
+	if reason != "" {
+		input = wrapperspb.String(reason)
+	}
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_ExecutionResumed{
+			ExecutionResumed: &protos.ExecutionResumedEvent{
+				Input: input,
+			},
+		},
+	}
+}
+
 func NewParentInfo(taskID int32, name string, iid string) *protos.ParentInstanceInfo {
 	return &protos.ParentInstanceInfo{
 		TaskScheduledId:       taskID,


### PR DESCRIPTION
This PR enables orchestrations to be suspended and resumed. Suspend and Resume are two new orchestration management operations.

When an orchestration is suspended, it will continue to receive new events and save them into the orchestration history but won't process them. Suspending an orchestration will add an `ExecutionSuspended` event in the history. It will also set the orchestration runtime status to "SUSPENDED".

When an orchestration is resumed, an `ExecutionResumed` event is added to the history. When processed, the history events that were previously ignored while the orchestration was suspended will be processed in the order they were originally received, causing the orchestration to continue executing as if it were never suspended.