### PR TITLE
Fix issue with concurrent timers

### DIFF
--- a/backend/runtimestate.go
+++ b/backend/runtimestate.go
@@ -158,7 +158,7 @@ func (s *OrchestrationRuntimeState) ApplyActions(actions []*protos.OrchestratorA
 			}
 		} else if createtimer := action.GetCreateTimer(); createtimer != nil {
 			s.AddEvent(helpers.NewTimerCreatedEvent(action.Id, createtimer.FireAt))
-			s.pendingTimers = append(s.pendingTasks, helpers.NewTimerFiredEvent(action.Id, createtimer.FireAt, currentTraceContext))
+			s.pendingTimers = append(s.pendingTimers, helpers.NewTimerFiredEvent(action.Id, createtimer.FireAt, currentTraceContext))
 		} else if scheduleTask := action.GetScheduleTask(); scheduleTask != nil {
 			scheduledEvent := helpers.NewTaskScheduledEvent(
 				action.Id,


### PR DESCRIPTION
This is a fix for https://github.com/dapr/dapr/issues/5978, which turned out to be a bug in how we track timer creation in the orchestration runtime state.

The core issue was that timer creation actions were getting overwritten if an orchestration scheduled multiple in a single batch. Depending on the backend implementation, this could result in stuck orchestrations that depended on these timers.

This PR also adds multiple test updates that would have helped identify this issue sooner.