### PR TITLE
Support for purge operation

### DIFF
--- a/api/client_grpc.go
+++ b/api/client_grpc.go
@@ -174,6 +174,23 @@ func (c *grpcClient) ResumeOrchestration(ctx context.Context, id InstanceID, rea
 	return nil
 }
 
+// PurgeOrchestrationState deletes the state of the specified orchestration instance.
+//
+// [api.ErrInstanceNotFound] is returned if the specified orchestration instance doesn't exist.
+func (c *grpcClient) PurgeOrchestrationState(ctx context.Context, id InstanceID) error {
+	req := &protos.PurgeInstancesRequest{
+		Request: &protos.PurgeInstancesRequest_InstanceId{InstanceId: string(id)},
+	}
+
+	res, err := c.client.PurgeInstances(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to purge orchestration state: %w", err)
+	} else if res.GetDeletedInstanceCount() == 0 {
+		return ErrInstanceNotFound
+	}
+	return nil
+}
+
 func makeGetInstanceRequest(id InstanceID, opts []FetchOrchestrationMetadataOptions) *protos.GetInstanceRequest {
 	req := &protos.GetInstanceRequest{InstanceId: string(id)}
 	for _, configure := range opts {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -85,6 +85,12 @@ type Backend interface {
 	//
 	// This is called when an internal failure occurs during activity work-item processing.
 	AbandonActivityWorkItem(context.Context, *ActivityWorkItem) error
+
+	// PurgeOrchestrationState deletes all saved state for the specified orchestration instance.
+	//
+	// [api.ErrInstanceNotFound] is returned if the specified orchestration instance doesn't exist.
+	// [api.ErrNotCompleted] is returned if the specified orchestration instance is still running.
+	PurgeOrchestrationState(context.Context, api.InstanceID) error
 }
 
 // MarshalHistoryEvent serializes the [HistoryEvent] into a protobuf byte array.

--- a/backend/client.go
+++ b/backend/client.go
@@ -26,6 +26,7 @@ type TaskHubClient interface {
 	RaiseEvent(ctx context.Context, id api.InstanceID, eventName string, data any) error
 	SuspendOrchestration(ctx context.Context, id api.InstanceID, reason string) error
 	ResumeOrchestration(ctx context.Context, id api.InstanceID, reason string) error
+	PurgeOrchestrationState(ctx context.Context, id api.InstanceID) error
 }
 
 type backendClient struct {
@@ -173,6 +174,17 @@ func (c *backendClient) ResumeOrchestration(ctx context.Context, id api.Instance
 	e := helpers.NewResumeOrchestrationEvent(reason)
 	if err := c.be.AddNewOrchestrationEvent(ctx, id, e); err != nil {
 		return fmt.Errorf("failed to resume orchestration: %w", err)
+	}
+	return nil
+}
+
+// PurgeOrchestrationState deletes the state of the specified orchestration instance.
+//
+// [api.ErrInstanceNotFound] is returned if the specified orchestration instance doesn't exist.
+// [api.ErrNotCompleted] is returned if the specified orchestration instance is still running.
+func (c *backendClient) PurgeOrchestrationState(ctx context.Context, id api.InstanceID) error {
+	if err := c.be.PurgeOrchestrationState(ctx, id); err != nil {
+		return fmt.Errorf("failed to purge orchestration state: %w", err)
 	}
 	return nil
 }

--- a/tests/mocks/Backend.go
+++ b/tests/mocks/Backend.go
@@ -515,6 +515,44 @@ func (_c *Backend_GetOrchestrationWorkItem_Call) Return(_a0 *backend.Orchestrati
 	return _c
 }
 
+// PurgeOrchestrationState provides a mock function with given fields: _a0, _a1
+func (_m *Backend) PurgeOrchestrationState(_a0 context.Context, _a1 api.InstanceID) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, api.InstanceID) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Backend_PurgeOrchestrationState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PurgeOrchestrationState'
+type Backend_PurgeOrchestrationState_Call struct {
+	*mock.Call
+}
+
+// PurgeOrchestrationState is a helper method to define mock.On call
+//  - _a0 context.Context
+//  - _a1 api.InstanceID
+func (_e *Backend_Expecter) PurgeOrchestrationState(_a0 interface{}, _a1 interface{}) *Backend_PurgeOrchestrationState_Call {
+	return &Backend_PurgeOrchestrationState_Call{Call: _e.mock.On("PurgeOrchestrationState", _a0, _a1)}
+}
+
+func (_c *Backend_PurgeOrchestrationState_Call) Run(run func(_a0 context.Context, _a1 api.InstanceID)) *Backend_PurgeOrchestrationState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(api.InstanceID))
+	})
+	return _c
+}
+
+func (_c *Backend_PurgeOrchestrationState_Call) Return(_a0 error) *Backend_PurgeOrchestrationState_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
 // Start provides a mock function with given fields: _a0
 func (_m *Backend) Start(_a0 context.Context) error {
 	ret := _m.Called(_a0)


### PR DESCRIPTION
This PR adds support for a "PurgeOrchestrationState" client operation which deletes all state associated with a completed orchestration.

It adds the following public APIs:
- Purge from an in-process client
- Purge from the gRPC client
- Purge in the `Backend` interface

I've also implemented purge in the `sqlite` backend implementation.

FYI @RyanLettieri since you'll need to consume this for the Dapr Workflow purge logic.