### PR TITLE
Update Raise Event client API (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ go func() {
 	var nameInput string
 	fmt.Scanln(&nameInput)
 	
-	client.RaiseEvent(ctx, id, "Name", nameInput)
+	opts := api.WithJsonSerializableEventData(nameInput)
+	client.RaiseEvent(ctx, id, "Name", opts)
 }()
 ```
 

--- a/api/client_grpc.go
+++ b/api/client_grpc.go
@@ -24,6 +24,9 @@ type NewOrchestrationOptions func(*protos.CreateInstanceRequest)
 // GetOrchestrationMetadataOptions is a set of options for fetching orchestration metadata.
 type FetchOrchestrationMetadataOptions func(*protos.GetInstanceRequest)
 
+// RaiseEventOptions is a set of options for raising an orchestration event.
+type RaiseEventOptions func(*protos.RaiseEventRequest)
+
 // WithInstanceID configures an explicit orchestration instance ID. If not specified,
 // a random UUID value will be used for the orchestration instance ID.
 func WithInstanceID(id InstanceID) NewOrchestrationOptions {
@@ -42,6 +45,13 @@ func WithInput(input any) NewOrchestrationOptions {
 	}
 }
 
+// WithRawInput configures an input for the orchestration. The specified input must be a string.
+func WithRawInput(rawInput string) NewOrchestrationOptions {
+	return func(req *protos.CreateInstanceRequest) {
+		req.Input = wrapperspb.String(rawInput)
+	}
+}
+
 // WithStartTime configures a start time at which the orchestration should start running.
 // Note that the actual start time could be later than the specified start time if the
 // task hub is under load or if the app is not running at the specified start time.
@@ -55,6 +65,21 @@ func WithStartTime(startTime time.Time) NewOrchestrationOptions {
 func WithFetchPayloads(fetchPayloads bool) FetchOrchestrationMetadataOptions {
 	return func(req *protos.GetInstanceRequest) {
 		req.GetInputsAndOutputs = fetchPayloads
+	}
+}
+
+// WithJsonSerializableEventData configures an event payload that can be serialized to JSON.
+func WithJsonSerializableEventData(data any) RaiseEventOptions {
+	return func(req *protos.RaiseEventRequest) {
+		bytes, _ := json.Marshal(data)
+		req.Input = wrapperspb.String(string(bytes))
+	}
+}
+
+// WithRawEventData configures an event payload that is a raw, unprocessed string (e.g. JSON data).
+func WithRawEventData(data string) RaiseEventOptions {
+	return func(req *protos.RaiseEventRequest) {
+		req.Input = wrapperspb.String(data)
 	}
 }
 

--- a/samples/externalevents.go
+++ b/samples/externalevents.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/microsoft/durabletask-go/api"
 	"github.com/microsoft/durabletask-go/task"
 )
 
@@ -31,7 +32,7 @@ func RunExternalEventsSample() {
 		fmt.Println("Enter your first name: ")
 		var nameInput string
 		fmt.Scanln(&nameInput)
-		if err = client.RaiseEvent(ctx, id, "Name", nameInput); err != nil {
+		if err = client.RaiseEvent(ctx, id, "Name", api.WithJsonSerializableEventData(nameInput)); err != nil {
 			panic(err)
 		}
 	}()

--- a/tests/orchestrations_test.go
+++ b/tests/orchestrations_test.go
@@ -387,7 +387,8 @@ func Test_ExternalEventOrchestration(t *testing.T) {
 	id, err := client.ScheduleNewOrchestration(ctx, "ExternalEventOrchestration", api.WithInput(0))
 	if assert.NoError(t, err) {
 		for i := 0; i < eventCount; i++ {
-			if err := client.RaiseEvent(ctx, id, "MyEvent", i); !assert.NoError(t, err) {
+			opts := api.WithJsonSerializableEventData(i)
+			if err := client.RaiseEvent(ctx, id, "MyEvent", opts); !assert.NoError(t, err) {
 				return
 			}
 		}
@@ -438,7 +439,7 @@ func Test_ExternalEventTimeout(t *testing.T) {
 				return
 			}
 			if raiseEvent {
-				if err := client.RaiseEvent(ctx, id, "MyEvent", nil); !assert.NoError(t, err) {
+				if err := client.RaiseEvent(ctx, id, "MyEvent"); !assert.NoError(t, err) {
 					return
 				}
 			}
@@ -519,7 +520,8 @@ func Test_SuspendResumeOrchestration(t *testing.T) {
 
 	// Raise a bunch of events to the orchestration (they should get buffered but not consumed)
 	for i := 0; i < eventCount; i++ {
-		if err := client.RaiseEvent(ctx, id, "MyEvent", i); !assert.NoError(t, err) {
+		opts := api.WithJsonSerializableEventData(i)
+		if err := client.RaiseEvent(ctx, id, "MyEvent", opts); !assert.NoError(t, err) {
 			return
 		}
 	}
@@ -588,7 +590,7 @@ func Test_PurgeCompletedOrchestration(t *testing.T) {
 	}
 
 	// Raise an event to the orchestration so that it can complete
-	if err = client.RaiseEvent(ctx, id, "MyEvent", nil); !assert.NoError(t, err) {
+	if err = client.RaiseEvent(ctx, id, "MyEvent"); !assert.NoError(t, err) {
 		return
 	}
 	if _, err = client.WaitForOrchestrationCompletion(ctx, id); !assert.NoError(t, err) {


### PR DESCRIPTION
This PR updates the `RaiseEvent` client API to move event payload inputs as optional parameters. It also removes the requirement that raise event payloads be JSON serializable.
