### PR TITLE
Add suspend/resume gRPC APIs

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -304,6 +304,26 @@ func (g *grpcExecutor) TerminateInstance(ctx context.Context, req *protos.Termin
 	return &protos.TerminateResponse{}, nil
 }
 
+// SuspendInstance implements protos.TaskHubSidecarServiceServer
+func (g *grpcExecutor) SuspendInstance(ctx context.Context, req *protos.SuspendRequest) (*protos.SuspendResponse, error) {
+	e := helpers.NewSuspendOrchestrationEvent(req.Reason.GetValue())
+	if err := g.backend.AddNewOrchestrationEvent(ctx, api.InstanceID(req.InstanceId), e); err != nil {
+		return nil, err
+	}
+
+	return &protos.SuspendResponse{}, nil
+}
+
+// ResumeInstance implements protos.TaskHubSidecarServiceServer
+func (g *grpcExecutor) ResumeInstance(ctx context.Context, req *protos.ResumeRequest) (*protos.ResumeResponse, error) {
+	e := helpers.NewResumeOrchestrationEvent(req.Reason.GetValue())
+	if err := g.backend.AddNewOrchestrationEvent(ctx, api.InstanceID(req.InstanceId), e); err != nil {
+		return nil, err
+	}
+
+	return &protos.ResumeResponse{}, nil
+}
+
 // WaitForInstanceCompletion implements protos.TaskHubSidecarServiceServer
 func (g *grpcExecutor) WaitForInstanceCompletion(ctx context.Context, req *protos.GetInstanceRequest) (*protos.GetInstanceResponse, error) {
 	return g.waitForInstance(ctx, req, func(m *api.OrchestrationMetadata) bool {

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -170,7 +170,7 @@ func (w *orchestratorProcessor) applyWorkItem(ctx context.Context, wi *Orchestra
 
 		// Special case logic for specific event types
 		if es := e.GetExecutionStarted(); es != nil {
-			w.logger.Infof("%v: starting new '%s' instance.", wi.InstanceID, es.Name)
+			w.logger.Infof("%v: starting new '%s' instance with ID = '%s'.", wi.InstanceID, es.Name, es.OrchestrationInstance.InstanceId)
 		} else if timerFired := e.GetTimerFired(); timerFired != nil {
 			// Timer spans are created and completed once the TimerFired event is received.
 			// TODO: Ideally we don't emit spans for cancelled timers. Is there a way to support this?

--- a/backend/runtimestate.go
+++ b/backend/runtimestate.go
@@ -170,6 +170,11 @@ func (s *OrchestrationRuntimeState) ApplyActions(actions []*protos.OrchestratorA
 			s.AddEvent(scheduledEvent)
 			s.pendingTasks = append(s.pendingTasks, scheduledEvent)
 		} else if createSO := action.GetCreateSubOrchestration(); createSO != nil {
+			// Autogenerate an instance ID for the sub-orchestration if none is provided, using a
+			// deterministic algorithm based on the parent instance ID to help enable de-duplication.
+			if createSO.InstanceId == "" {
+				createSO.InstanceId = fmt.Sprintf("%s:%04x", s.instanceID, action.Id)
+			}
 			s.AddEvent(helpers.NewSubOrchestrationCreatedEvent(
 				action.Id,
 				createSO.Name,


### PR DESCRIPTION
Also:
- Auto-generate sub-orchestration IDs if not specified
- Fix bug in backoff polling algorithm that was causing slow polling
- Minor logging improvements