### PR TITLE
ContinueAsNew with carryover events

### DIFF
--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -96,8 +96,6 @@ func (w *orchestratorProcessor) ProcessWorkItem(ctx context.Context, cwi WorkIte
 			// When continuing-as-new, we re-execute the orchestrator from the beginning with a truncated state in a tight loop
 			// until the orchestrator performs some non-continue-as-new action.
 			if continuedAsNew {
-				w.logger.Debugf("%v: continued-as-new with %d new event(s).", wi.InstanceID, len(wi.State.NewEvents()))
-
 				const MaxContinueAsNewCount = 20
 				if continueAsNewCount >= MaxContinueAsNewCount {
 					return fmt.Errorf("exceeded tight-loop continue-as-new limit of %d iterations", MaxContinueAsNewCount)

--- a/tests/runtimestate_test.go
+++ b/tests/runtimestate_test.go
@@ -146,7 +146,7 @@ func Test_CompletedSubOrchestration(t *testing.T) {
 	}
 }
 
-func Test_ContinueAsNew(t *testing.T) {
+func Test_RuntimeState_ContinueAsNew(t *testing.T) {
 	iid := "abc"
 	expectedName := "MyOrchestration"
 	continueAsNewInput := "\"done!\""


### PR DESCRIPTION
This PR allows an orchestration with unprocessed external events to carry them over to the next generation when calling `ContinueAsNew`. This behavior must be opted-into using a new options value, `WithKeepUnprocessedEvents()`:

```go
ctx.ContinueAsNew(value, task.WithKeepUnprocessedEvents())
```