### PR TITLE
Fix gRPC executor regression

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -45,8 +45,8 @@ type Executor interface {
 type grpcExecutor struct {
 	protos.UnimplementedTaskHubSidecarServiceServer
 	workItemQueue        chan *protos.WorkItem
-	pendingOrchestrators sync.Map // map[api.InstanceID]*ExecutionResults
-	pendingActivities    sync.Map // map[string]*activityExecutionResult
+	pendingOrchestrators *sync.Map // map[api.InstanceID]*ExecutionResults
+	pendingActivities    *sync.Map // map[string]*activityExecutionResult
 	backend              Backend
 	logger               Logger
 	onWorkItemConnection func(context.Context) error
@@ -78,9 +78,11 @@ func WithStreamShutdownChannel(c <-chan any) grpcExecutorOptions {
 
 func NewGrpcExecutor(grpcServer *grpc.Server, be Backend, logger Logger, opts ...grpcExecutorOptions) Executor {
 	executor := &grpcExecutor{
-		workItemQueue: make(chan *protos.WorkItem),
-		backend:       be,
-		logger:        logger,
+		workItemQueue:        make(chan *protos.WorkItem),
+		backend:              be,
+		logger:               logger,
+		pendingOrchestrators: &sync.Map{},
+		pendingActivities:    &sync.Map{},
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Fixed a regression introduced in #16, which complete broke out-of-proc orchestration execution. 😬😓

This highlights the need for automated end-to-end testing, which would have caught this had it been run as part of the previous PR validation. A subsequent PR will include a suite that covers the gRPC code path.

This PR was manually verified against both the Durable Task Python SDK and the Durable Task .NET SDK (both of which are currently used by Dapr).