### PR TITLE
Small tweak to IsDurableTaskGrpcRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed another ticker memory leak ([#30](https://github.com/microsoft/durabletask-go/pull/30)) - contributed by [@DeepanshuA](https://github.com/DeepanshuA) and [@ItalyPaleAle](https://github.com/ItalyPaleAle)
 
+### Changed
+
+- Small tweak to IsDurableTaskGrpcRequest ([#29](https://github.com/microsoft/durabletask-go/pull/29)) - contributed by [@ItalyPaleAle](https://github.com/ItalyPaleAle)
+
 ## [v0.3.0] - 2023-07-13
 
 This is a breaking change release that introduces the ability to run workflows in 

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -57,7 +57,7 @@ type grpcExecutorOptions func(g *grpcExecutor)
 // IsDurableTaskGrpcRequest returns true if the specified gRPC method name represents an operation
 // that is compatible with the gRPC executor.
 func IsDurableTaskGrpcRequest(fullMethodName string) bool {
-	return strings.Index(fullMethodName, "/TaskHubSidecarService") == 0
+	return strings.HasPrefix(fullMethodName, "/TaskHubSidecarService/")
 }
 
 // WithOnGetWorkItemsConnectionCallback allows the caller to get a notification when an external process


### PR DESCRIPTION
Adds a / at the end to ensure it matches the full prefix.

Also uses strings.HasPrefix which doesn't iterate through the entire string if first bytes don't match.