### PR TITLE
Memory Leak: Let's not create ticker each time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.1] - 2023-09-08
+
+### Fixed
+
+- Fixed another ticker memory leak ([#30](https://github.com/microsoft/durabletask-go/pull/30)) - contributed by [@DeepanshuA](https://github.com/DeepanshuA) and [@ItalyPaleAle](https://github.com/ItalyPaleAle)
+
 ## [v0.3.0] - 2023-07-13
 
 This is a breaking change release that introduces the ability to run workflows in 

--- a/backend/client.go
+++ b/backend/client.go
@@ -106,10 +106,14 @@ func (c *backendClient) waitForOrchestrationCondition(ctx context.Context, id ap
 	b.Reset()
 
 	for {
+		t := time.NewTimer(b.NextBackOff())
 		select {
 		case <-ctx.Done():
+			if !t.Stop() {
+				<-t.C
+			}
 			return nil, ctx.Err()
-		case <-time.After(b.NextBackOff()):
+		case <-t.C:
 			metadata, err := c.FetchOrchestrationMetadata(ctx, id)
 			if err != nil {
 				return nil, err

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -109,7 +109,7 @@ func (w *worker) Start(ctx context.Context) {
 		ticker:
 			for range ticker.C {
 				if ok, err := w.ProcessNext(ctx); ok {
-					// found a work item - reset the ticker to check for the next one right away
+					// found a work item - reset the backoff and check for the next item
 					break ticker
 				} else if err != nil && errors.Is(err, ctx.Err()) {
 					w.logger.Infof("%v: received cancellation signal", w.Name())

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -90,35 +90,59 @@ func (w *worker) Start(ctx context.Context) {
 	// TODO: Check for already started worker
 	ctx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
-	b := &backoff.ExponentialBackOff{
-		InitialInterval:     50 * time.Millisecond,
-		MaxInterval:         5 * time.Second,
-		Multiplier:          1.05,
-		RandomizationFactor: 0.05,
-		Stop:                backoff.Stop,
-		Clock:               backoff.SystemClock,
-	}
-	cb := backoff.WithContext(b, ctx)
+
 	go func() {
-		ticker := backoff.NewTicker(b)
-		defer ticker.Stop()
+		var b backoff.BackOff = &backoff.ExponentialBackOff{
+			InitialInterval:     50 * time.Millisecond,
+			MaxInterval:         5 * time.Second,
+			Multiplier:          1.05,
+			RandomizationFactor: 0.05,
+			Stop:                backoff.Stop,
+			Clock:               backoff.SystemClock,
+		}
+		b = backoff.WithContext(b, ctx)
+		b.Reset()
+
 	loop:
 		for {
-			cb.Reset()
-			w.waiting = false
-		ticker:
-			for range ticker.C {
-				if ok, err := w.ProcessNext(ctx); ok {
-					// found a work item - reset the backoff and check for the next item
-					break ticker
-				} else if err != nil && errors.Is(err, ctx.Err()) {
+			// returns right away, with "ok" if a work item was found
+			ok, err := w.ProcessNext(ctx)
+
+			switch {
+			case ok:
+				// found a work item - reset the backoff and check for the next item
+				b.Reset()
+			case err != nil && errors.Is(err, ctx.Err()):
+				// there's an error and it's due to the context being canceled
+				w.logger.Infof("%v: received cancellation signal", w.Name())
+				break loop
+			case err != nil:
+				// another error was encountered
+				// log the error and inject some extra sleep to avoid tight failure loops
+				w.logger.Errorf("unexpected worker error: %v. Adding 5 extra seconds of backoff.", err)
+				t := time.NewTimer(5 * time.Second)
+				select {
+				case <-t.C:
+					// nop - all good
+				case <-ctx.Done():
+					if !t.Stop() {
+						<-t.C
+					}
 					w.logger.Infof("%v: received cancellation signal", w.Name())
 					break loop
-				} else if err != nil {
-					// log the error and inject some extra sleep to avoid tight failure loops
-					w.logger.Errorf("unexpected worker error: %v. Adding 5 extra seconds of backoff.", err)
-					// TODO: Make this a cancellable sleep
-					time.Sleep(5 * time.Second)
+				}
+			default:
+				// no work item found, so sleep until the next backoff
+				t := time.NewTimer(b.NextBackOff())
+				select {
+				case <-t.C:
+					// nop - all good
+				case <-ctx.Done():
+					if !t.Stop() {
+						<-t.C
+					}
+					w.logger.Infof("%v: received cancellation signal", w.Name())
+					break loop
 				}
 			}
 		}

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -98,34 +98,27 @@ func (w *worker) Start(ctx context.Context) {
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}
+	cb := backoff.WithContext(b, ctx)
 	go func() {
 		ticker := backoff.NewTicker(b)
 		defer ticker.Stop()
 	loop:
 		for {
-			b.Reset()
+			cb.Reset()
 			w.waiting = false
 		ticker:
 			for range ticker.C {
-				select {
-				case <-ctx.Done():
+				if ok, err := w.ProcessNext(ctx); ok {
+					// found a work item - reset the ticker to check for the next one right away
+					break ticker
+				} else if err != nil && errors.Is(err, ctx.Err()) {
 					w.logger.Infof("%v: received cancellation signal", w.Name())
-					ticker.Stop()
 					break loop
-				default:
-					if ok, err := w.ProcessNext(ctx); ok {
-						// found a work item - reset the ticker to check for the next one right away
-						break ticker
-					} else if err != nil && errors.Is(err, ctx.Err()) {
-						w.logger.Infof("%v: received cancellation signal", w.Name())
-						ticker.Stop()
-						break loop
-					} else if err != nil {
-						// log the error and inject some extra sleep to avoid tight failure loops
-						w.logger.Errorf("unexpected worker error: %v. Adding 5 extra seconds of backoff.", err)
-						// TODO: Make this a cancellable sleep
-						time.Sleep(5 * time.Second)
-					}
+				} else if err != nil {
+					// log the error and inject some extra sleep to avoid tight failure loops
+					w.logger.Errorf("unexpected worker error: %v. Adding 5 extra seconds of backoff.", err)
+					// TODO: Make this a cancellable sleep
+					time.Sleep(5 * time.Second)
 				}
 			}
 		}


### PR DESCRIPTION
Currently, we create ticker each time.

I ran 500 workflow instances concurrently. All workflows of same type.
Each workflow having 4 activities and each activity just doing only an addition of 1 to input.

After all these workflows had run, I collected heap dump. It resulted in following:
<img width="949" alt="image" src="https://github.com/microsoft/durabletask-go/assets/24491296/ac9f4ff1-c5ca-41a1-bec9-b115ada06398">

<img width="956" alt="image" src="https://github.com/microsoft/durabletask-go/assets/24491296/0fd92696-dff2-45a4-a81f-7444a91b11db">

So, in all around 8.8+2.2 = 11% of current inuse_space. In some other runs, it reached a high of around 14% as well.

<img width="915" alt="image" src="https://github.com/microsoft/durabletask-go/assets/24491296/ff863fee-20a6-432d-8cdb-6810f8f971b7">

<img width="903" alt="image" src="https://github.com/microsoft/durabletask-go/assets/24491296/118f01fb-faaf-4f50-b18d-40219d33b0a8">

In this change, we don't create Ticker each time. Rather, we just create it once and when ProcessNext is called, we DON'T Stop current Ticker and start New. RATHER, we just Reset the backoff.

After the change, I don't see it in inuse_space:
<img width="908" alt="image" src="https://github.com/microsoft/durabletask-go/assets/24491296/037d756a-fb09-4432-a07f-6b46e1557415">
