### PR TITLE
Improve logging and handling of shutdown process

### DIFF
--- a/backend/activity.go
+++ b/backend/activity.go
@@ -49,7 +49,7 @@ func (p *activityProcessor) ProcessWorkItem(ctx context.Context, wi WorkItem) er
 
 	ts := awi.NewEvent.GetTaskScheduled()
 	if ts == nil {
-		return fmt.Errorf("invalid TaskScheduled event")
+		return fmt.Errorf("%v: invalid TaskScheduled event", awi.InstanceID)
 	}
 
 	// Create span as child of spanContext found in TaskScheduledEvent
@@ -85,8 +85,11 @@ func (p *activityProcessor) ProcessWorkItem(ctx context.Context, wi WorkItem) er
 // CompleteWorkItem implements TaskDispatcher
 func (ap *activityProcessor) CompleteWorkItem(ctx context.Context, wi WorkItem) error {
 	awi := wi.(*ActivityWorkItem)
+	if awi.Result == nil {
+		return fmt.Errorf("can't complete work item '%s' with nil result", wi.Description())
+	}
 	if awi.Result.GetTaskCompleted() == nil && awi.Result.GetTaskFailed() == nil {
-		return fmt.Errorf("invalid result on activity work item '%s'", wi.Description())
+		return fmt.Errorf("can't complete work item '%s', which isn't TaskCompleted or TaskFailed", wi.Description())
 	}
 
 	return ap.be.CompleteActivityWorkItem(ctx, awi)

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -115,6 +115,7 @@ func (executor *grpcExecutor) ExecuteOrchestrator(ctx context.Context, iid api.I
 	// This will block if the worker isn't listening for work items.
 	select {
 	case <-ctx.Done():
+		executor.logger.Warnf("%s: context canceled before dispatching orchestrator work item", iid)
 		return nil, ctx.Err()
 	case executor.workItemQueue <- workItem:
 	}
@@ -123,6 +124,7 @@ func (executor *grpcExecutor) ExecuteOrchestrator(ctx context.Context, iid api.I
 	// TODO: Timeout logic - i.e. handle the case where we never hear back from the remote worker (due to a hang, etc.).
 	select {
 	case <-ctx.Done():
+		executor.logger.Warnf("%s: context canceled before receiving orchestrator result", iid)
 		return nil, ctx.Err()
 	case <-result.complete:
 	}
@@ -154,6 +156,7 @@ func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.Insta
 	// This will block if the worker isn't listening for work items.
 	select {
 	case <-ctx.Done():
+		executor.logger.Warnf("%s/%s#%d: context canceled before dispatching activity work item", iid, task.Name, e.EventId)
 		return nil, ctx.Err()
 	case executor.workItemQueue <- workItem:
 	}
@@ -162,6 +165,8 @@ func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.Insta
 	// TODO: Timeout logic
 	select {
 	case <-ctx.Done():
+		executor.logger.Warnf("%s/%s#%d: context canceled before receiving activity result", iid, task.Name, e.EventId)
+		return nil, ctx.Err()
 	case <-result.complete:
 	}
 

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -216,6 +216,7 @@ func (w *worker) processWorkItem(ctx context.Context, wi WorkItem) {
 		if err := w.processor.AbandonWorkItem(ctx, wi); err != nil {
 			w.logger.Errorf("%v: failed to abandon work item: %v", w.Name(), err)
 		}
+		return
 	}
 
 	if err := w.processor.CompleteWorkItem(ctx, wi); err != nil {


### PR DESCRIPTION
Depending on the timing of worker shutdown (for example, if it happens while there are outstanding activity or orchestrator executions), there can be confusing error messages written to the logs. This PR cleans up the error handling and logging for some of the commonly encountered shutdown paths.