### PR TITLE
Update supported Go versions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.20.x', '1.19.x', '1.18.x' ]
+        go-version: [ '1.21.x', '1.20.x', '1.19.x' ]
         
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ git clone --recurse-submodules https://github.com/microsoft/durabletask-go
 
 ## Building the project
 
-This project requires go v1.18.x or greater. You can build a standalone executable by simply running `go build` at the project root.
+This project requires go v1.19.x or greater. You can build a standalone executable by simply running `go build` at the project root.
 
 ### Generating protobuf
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/durabletask-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3


### PR DESCRIPTION
Go 1.18 has been out of support for a while now and Go 1.21 was released a few months ago. Time to update.

A big motivation for this shift is so we can merge https://github.com/microsoft/durabletask-go/pull/37, which is a security fix in the OTel libraries that require features only found in Go 1.19+.