### PR TITLE
Fix: PurgeOrchestration errors out when used with retryable sub-orchestrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Cascading Terminate and Purge support ([#47](https://github.com/microsoft/durabletask-go/pull/47)) - by [@shivamkm07](https://github.com/shivamkm07)
+- Cascading Terminate and Purge support ([#47](https://github.com/microsoft/durabletask-go/pull/47) and [#63](https://github.com/microsoft/durabletask-go/pull/63)) - by [@shivamkm07](https://github.com/shivamkm07)
 
 ### Changed
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -180,16 +180,20 @@ func terminateSubOrchestrationInstances(ctx context.Context, be Backend, iid api
 
 // getSubOrchestrationInstances returns the instance IDs of all sub-orchestrations in the specified events.
 func getSubOrchestrationInstances(oldEvents []*HistoryEvent, newEvents []*HistoryEvent) []api.InstanceID {
-	subOrchestrationInstances := make([]api.InstanceID, 0, len(oldEvents)+len(newEvents))
+	subOrchestrationInstancesMap := make(map[api.InstanceID]struct{}, len(oldEvents)+len(newEvents))
 	for _, e := range oldEvents {
 		if created := e.GetSubOrchestrationInstanceCreated(); created != nil {
-			subOrchestrationInstances = append(subOrchestrationInstances, api.InstanceID(created.InstanceId))
+			subOrchestrationInstancesMap[api.InstanceID(created.InstanceId)] = struct{}{}
 		}
 	}
 	for _, e := range newEvents {
 		if created := e.GetSubOrchestrationInstanceCreated(); created != nil {
-			subOrchestrationInstances = append(subOrchestrationInstances, api.InstanceID(created.InstanceId))
+			subOrchestrationInstancesMap[api.InstanceID(created.InstanceId)] = struct{}{}
 		}
+	}
+	subOrchestrationInstances := make([]api.InstanceID, 0, len(subOrchestrationInstancesMap))
+	for orch := range subOrchestrationInstancesMap {
+		subOrchestrationInstances = append(subOrchestrationInstances, orch)
 	}
 	return subOrchestrationInstances
 }


### PR DESCRIPTION
On trying to purge an orchestration that creates retryable sub-orchestrations, it fails with `Segmentation Fault` error. More details of the issue can be found here: https://github.com/dapr/dapr/issues/7422

The issue happens because in case of retryable sub-orchestrations, there are multiple instances of same sub-orchestration (with same instanceId) in the orchestration state and the purge logic tries to purge each of them recursively and so fails while trying to purge a sub-orchestration again which has been already purged. The PR fixes the implementation to filter out duplicate instanceIDs while purging. 