### PR TITLE
Few cosmetic tweaks

### DIFF
--- a/backend/activity.go
+++ b/backend/activity.go
@@ -86,10 +86,10 @@ func (p *activityProcessor) ProcessWorkItem(ctx context.Context, wi WorkItem) er
 func (ap *activityProcessor) CompleteWorkItem(ctx context.Context, wi WorkItem) error {
 	awi := wi.(*ActivityWorkItem)
 	if awi.Result == nil {
-		return fmt.Errorf("can't complete work item '%s' with nil result", wi.Description())
+		return fmt.Errorf("can't complete work item '%s' with nil result", wi)
 	}
 	if awi.Result.GetTaskCompleted() == nil && awi.Result.GetTaskFailed() == nil {
-		return fmt.Errorf("can't complete work item '%s', which isn't TaskCompleted or TaskFailed", wi.Description())
+		return fmt.Errorf("can't complete work item '%s', which isn't TaskCompleted or TaskFailed", wi)
 	}
 
 	return ap.be.CompleteActivityWorkItem(ctx, awi)

--- a/backend/workitem.go
+++ b/backend/workitem.go
@@ -11,7 +11,8 @@ import (
 var ErrNoWorkItems = errors.New("no work items were found")
 
 type WorkItem interface {
-	Description() string
+	fmt.Stringer
+	IsWorkItem() bool
 }
 
 type OrchestrationWorkItem struct {
@@ -23,19 +24,24 @@ type OrchestrationWorkItem struct {
 	Properties map[string]interface{}
 }
 
-func (wi *OrchestrationWorkItem) Description() string {
-	return fmt.Sprintf("%v (%d event(s))", wi.InstanceID, len(wi.NewEvents))
+// String implements core.WorkItem and fmt.Stringer
+func (wi OrchestrationWorkItem) String() string {
+	return fmt.Sprintf("%s (%d event(s))", wi.InstanceID, len(wi.NewEvents))
+}
+
+// IsWorkItem implements core.WorkItem
+func (wi OrchestrationWorkItem) IsWorkItem() bool {
+	return true
 }
 
 func (wi *OrchestrationWorkItem) GetAbandonDelay() time.Duration {
-	if wi.RetryCount == 0 {
+	switch {
+	case wi.RetryCount == 0:
 		return time.Duration(0) // no delay
-	} else {
-		if wi.RetryCount > 100 {
-			return 5 * time.Minute // max delay
-		} else {
-			return time.Duration(wi.RetryCount) * time.Second // linear backoff
-		}
+	case wi.RetryCount > 100:
+		return 5 * time.Minute // max delay
+	default:
+		return time.Duration(wi.RetryCount) * time.Second // linear backoff
 	}
 }
 
@@ -48,9 +54,14 @@ type ActivityWorkItem struct {
 	Properties     map[string]interface{}
 }
 
-// Description implements core.WorkItem
-func (wi *ActivityWorkItem) Description() string {
+// String implements core.WorkItem and fmt.Stringer
+func (wi ActivityWorkItem) String() string {
 	name := wi.NewEvent.GetTaskScheduled().GetName()
 	taskID := wi.NewEvent.EventId
 	return fmt.Sprintf("%s/%s#%d", wi.InstanceID, name, taskID)
+}
+
+// IsWorkItem implements core.WorkItem
+func (wi ActivityWorkItem) IsWorkItem() bool {
+	return true
 }

--- a/samples/distributedtracing/distributedtracing.go
+++ b/samples/distributedtracing/distributedtracing.go
@@ -22,7 +22,7 @@ func main() {
 	// Tracing can be configured independently of the orchestration code.
 	tp, err := ConfigureZipkinTracing()
 	if err != nil {
-		log.Fatalf("Failed to create tracer: %w", err)
+		log.Fatalf("Failed to create tracer: %v", err)
 	}
 	defer func() {
 		if err := tp.Shutdown(context.Background()); err != nil {


### PR DESCRIPTION
Just some small cosmetic tweaks.

1. In the WorkItem interface, change the required method to `IsWorkItem() bool` which better identifies objects that are work items. Renamed `Description() string` to `String() string` so it implements the more idiomatic `fmt.Stringer`.
2. Fixed a warning due to `log.Fatalf` not supporting `%w`