### PR TITLE
add retries to GetWorkItems stream connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump google.golang.org/grpc from 1.53.0 to 1.56.3 ([#39](https://github.com/microsoft/durabletask-go/pull/39))
 - Updated durabletask-protobuf submodule to [`4207e1d`](https://github.com/microsoft/durabletask-protobuf/commit/4207e1dbd14cedc268f69c3befee60fcaad19367)
+- Add retries to GetWorkItems stream connection ([#72](https://github.com/microsoft/durabletask-go/pull/72)) - by [@famarting](https://github.com/famarting)
 
 ## [v0.4.0] - 2023-12-18
 

--- a/backend/activity.go
+++ b/backend/activity.go
@@ -23,7 +23,7 @@ type ActivityExecutor interface {
 
 func NewActivityTaskWorker(be Backend, executor ActivityExecutor, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker {
 	processor := newActivityProcessor(be, executor)
-	return NewTaskWorker(be, processor, logger, opts...)
+	return NewTaskWorker(processor, logger, opts...)
 }
 
 func newActivityProcessor(be Backend, executor ActivityExecutor) TaskProcessor {

--- a/backend/orchestration.go
+++ b/backend/orchestration.go
@@ -35,7 +35,7 @@ func NewOrchestrationWorker(be Backend, executor OrchestratorExecutor, logger Lo
 		executor: executor,
 		logger:   logger,
 	}
-	return NewTaskWorker(be, processor, logger, opts...)
+	return NewTaskWorker(processor, logger, opts...)
 }
 
 // Name implements TaskProcessor

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -32,7 +32,6 @@ type TaskProcessor interface {
 }
 
 type worker struct {
-	backend Backend
 	options *WorkerOptions
 	logger  Logger
 	// dispatchSemaphore is for throttling orchestration concurrency.
@@ -66,13 +65,12 @@ func WithMaxParallelism(n int32) NewTaskWorkerOptions {
 	}
 }
 
-func NewTaskWorker(be Backend, p TaskProcessor, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker {
+func NewTaskWorker(p TaskProcessor, logger Logger, opts ...NewTaskWorkerOptions) TaskWorker {
 	options := &WorkerOptions{MaxParallelWorkItems: 1}
 	for _, configure := range opts {
 		configure(options)
 	}
 	return &worker{
-		backend:           be,
 		processor:         p,
 		logger:            logger,
 		dispatchSemaphore: semaphore.New(int(options.MaxParallelWorkItems)),


### PR DESCRIPTION
fix for https://github.com/microsoft/durabletask-go/issues/70

This PR adds infinite retries (with exponential backoff up to 15s) to the `GetWorkItems` call in the client worker. IMO it makes sense to do infinite retries, since the function is not blocking the user and the function signature does not allow to pass errors asynchronously, the only control the user has over `StartWorkItemListener` is via the context passed as parameter.

Also it makes sense to retry forever since the user would expect this work item listener to be reliable in order to always receive and process work.