### PR TITLE
improve worker shutdown logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Make WaitForOrchestrationXXX gRPC APIs resilient ([#80](https://github.com/microsoft/durabletask-go/pull/81)) - by [@famarting](https://github.com/famarting)
+- Make WaitForOrchestrationXXX gRPC APIs resilient ([#80](https://github.com/microsoft/durabletask-go/pull/80)) - by [@famarting](https://github.com/famarting)
+- Improve worker shutdown logic ([#77](https://github.com/microsoft/durabletask-go/pull/77)) - by [@famarting](https://github.com/famarting)
 
 ## [v0.5.0] - 2024-06-28
 

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -223,13 +223,13 @@ func (w *worker) processWorkItem(ctx context.Context, wi WorkItem) {
 	}
 
 	if err := w.processor.ProcessWorkItem(ctx, wi); err != nil {
-		if w.stop.Load() {
-			ctx = context.Background()
-		}
 		if errors.Is(err, ctx.Err()) {
 			w.logger.Warnf("%v: abandoning work item due to cancellation", w.Name())
 		} else {
 			w.logger.Errorf("%v: failed to process work item: %v", w.Name(), err)
+		}
+		if w.stop.Load() {
+			ctx = context.Background()
 		}
 		if err := w.processor.AbandonWorkItem(ctx, wi); err != nil {
 			w.logger.Errorf("%v: failed to abandon work item: %v", w.Name(), err)
@@ -238,13 +238,13 @@ func (w *worker) processWorkItem(ctx context.Context, wi WorkItem) {
 	}
 
 	if err := w.processor.CompleteWorkItem(ctx, wi); err != nil {
-		if w.stop.Load() {
-			ctx = context.Background()
-		}
 		if errors.Is(err, ctx.Err()) {
 			w.logger.Warnf("%v: failed to complete work item due to cancellation", w.Name())
 		} else {
 			w.logger.Errorf("%v: failed to complete work item: %v", w.Name(), err)
+		}
+		if w.stop.Load() {
+			ctx = context.Background()
 		}
 		if err := w.processor.AbandonWorkItem(ctx, wi); err != nil {
 			w.logger.Errorf("%v: failed to abandon work item: %v", w.Name(), err)

--- a/tests/mocks/task.go
+++ b/tests/mocks/task.go
@@ -12,6 +12,7 @@ import (
 
 var _ backend.TaskProcessor = &TestTaskProcessor{}
 
+// TestTaskProcessor implements a dummy task processor useful for testing
 type TestTaskProcessor struct {
 	name string
 

--- a/tests/mocks/task.go
+++ b/tests/mocks/task.go
@@ -1,0 +1,127 @@
+package mocks
+
+import (
+	context "context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	backend "github.com/microsoft/durabletask-go/backend"
+)
+
+var _ backend.TaskProcessor = &TestTaskProcessor{}
+
+type TestTaskProcessor struct {
+	name string
+
+	processingBlocked atomic.Bool
+
+	workItemMu sync.Mutex
+	workItems  []backend.WorkItem
+
+	abandonedWorkItemMu sync.Mutex
+	abandonedWorkItems  []backend.WorkItem
+
+	completedWorkItemMu sync.Mutex
+	completedWorkItems  []backend.WorkItem
+}
+
+func NewTestTaskPocessor(name string) *TestTaskProcessor {
+	return &TestTaskProcessor{
+		name: name,
+	}
+}
+
+func (t *TestTaskProcessor) BlockProcessing() {
+	t.processingBlocked.Store(true)
+}
+
+func (t *TestTaskProcessor) UnblockProcessing() {
+	t.processingBlocked.Store(false)
+}
+
+func (t *TestTaskProcessor) PendingWorkItems() []backend.WorkItem {
+	t.workItemMu.Lock()
+	defer t.workItemMu.Unlock()
+
+	// copy array
+	return append([]backend.WorkItem{}, t.workItems...)
+}
+
+func (t *TestTaskProcessor) AbandonedWorkItems() []backend.WorkItem {
+	t.abandonedWorkItemMu.Lock()
+	defer t.abandonedWorkItemMu.Unlock()
+
+	// copy array
+	return append([]backend.WorkItem{}, t.abandonedWorkItems...)
+}
+
+func (t *TestTaskProcessor) CompletedWorkItems() []backend.WorkItem {
+	t.completedWorkItemMu.Lock()
+	defer t.completedWorkItemMu.Unlock()
+
+	// copy array
+	return append([]backend.WorkItem{}, t.completedWorkItems...)
+}
+
+func (t *TestTaskProcessor) AddWorkItems(wis ...backend.WorkItem) {
+	t.workItemMu.Lock()
+	defer t.workItemMu.Unlock()
+
+	t.workItems = append(t.workItems, wis...)
+}
+
+func (t *TestTaskProcessor) Name() string {
+	return t.name
+}
+
+func (t *TestTaskProcessor) FetchWorkItem(context.Context) (backend.WorkItem, error) {
+	t.workItemMu.Lock()
+	defer t.workItemMu.Unlock()
+
+	if len(t.workItems) == 0 {
+		return nil, backend.ErrNoWorkItems
+	}
+
+	// pop first item
+	i := 0
+	wi := t.workItems[i]
+	t.workItems = append(t.workItems[:i], t.workItems[i+1:]...)
+
+	return wi, nil
+}
+
+func (t *TestTaskProcessor) ProcessWorkItem(ctx context.Context, wi backend.WorkItem) error {
+	if !t.processingBlocked.Load() {
+		return nil
+	}
+	// wait for context cancellation or until processing is unblocked
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("dummy error processing work item")
+		default:
+			if !t.processingBlocked.Load() {
+				return nil
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func (t *TestTaskProcessor) AbandonWorkItem(ctx context.Context, wi backend.WorkItem) error {
+	t.abandonedWorkItemMu.Lock()
+	defer t.abandonedWorkItemMu.Unlock()
+
+	t.abandonedWorkItems = append(t.abandonedWorkItems, wi)
+	return nil
+}
+
+func (t *TestTaskProcessor) CompleteWorkItem(ctx context.Context, wi backend.WorkItem) error {
+	t.completedWorkItemMu.Lock()
+	defer t.completedWorkItemMu.Unlock()
+
+	t.completedWorkItems = append(t.completedWorkItems, wi)
+	return nil
+}


### PR DESCRIPTION
This PR updates the logic for stopping the task worker and improves the logic for draining tasks currently being processed

This should increase the reliability of correctly completing or abandoning tasks that are being processed while a shutdown happens.

Added tests and a new hand made "mock" to help test all of this