### PR TITLE
Enhance GetInstance method to handle instance not found error gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make WaitForOrchestrationXXX gRPC APIs resilient ([#80](https://github.com/microsoft/durabletask-go/pull/80)) - by [@famarting](https://github.com/famarting)
 - Improve worker shutdown logic ([#77](https://github.com/microsoft/durabletask-go/pull/77)) - by [@famarting](https://github.com/famarting)
+- Fix GetInstance gRPC API to return not found when instance is not found ([#87](https://github.com/microsoft/durabletask-go/pull/87)) - by [@cgillum](https://github.com/cgillum)
 
 ## [v0.5.0] - 2024-06-28
 

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -371,8 +371,12 @@ func (grpcExecutor) DeleteTaskHub(context.Context, *protos.DeleteTaskHubRequest)
 func (g *grpcExecutor) GetInstance(ctx context.Context, req *protos.GetInstanceRequest) (*protos.GetInstanceResponse, error) {
 	metadata, err := g.backend.GetOrchestrationMetadata(ctx, api.InstanceID(req.InstanceId))
 	if err != nil {
+		if errors.Is(err, api.ErrInstanceNotFound) {
+			return &protos.GetInstanceResponse{Exists: false}, nil
+		}
 		return nil, err
 	}
+
 	if metadata == nil {
 		return &protos.GetInstanceResponse{Exists: false}, nil
 	}


### PR DESCRIPTION
Fixes irritating behavior where a gRPC error is returned by client operations to fetch orchestration state when the orchestration doesn’t exist. Instead, we should return a proper response indicating that the orchestration doesn’t exist.