### PR TITLE
Update supported go versions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.22.x', '1.21.x', '1.20.x' ]
+        go-version: [ '1.24.x', '1.23.x' ]
 
     # Boot up a local, clean postgres instance for the postgres tests
     services:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/durabletask-go
 
-go 1.21
+go 1.23
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3


### PR DESCRIPTION
Go 1.21 and 1.22 are no longer considered supported, so removing them from the build and setting 1.23 as the minimum version.