### PR TITLE
[postgres] Fix CallSubOrchestrator failure processing

### DIFF
--- a/backend/postgres/postgres.go
+++ b/backend/postgres/postgres.go
@@ -361,7 +361,10 @@ func (be *postgresBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi
 		for _, msg := range wi.State.PendingMessages() {
 			if es := msg.HistoryEvent.GetExecutionStarted(); es != nil {
 				// Need to insert a new row into the DB
-				if _, err := be.createOrchestrationInstanceInternal(ctx, msg.HistoryEvent, tx); err != nil {
+				if _, err := be.createOrchestrationInstanceInternal(ctx, msg.HistoryEvent, tx, backend.WithOrchestrationIdReusePolicy(&protos.OrchestrationIdReusePolicy{
+					OperationStatus: []protos.OrchestrationStatus{protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED},
+					Action:          api.REUSE_ID_ACTION_TERMINATE,
+				})); err != nil {
 					if errors.Is(err, backend.ErrDuplicateEvent) {
 						be.logger.Warnf(
 							"%v: dropping sub-orchestration creation event because an instance with the target ID (%v) already exists.",


### PR DESCRIPTION
When SubOrchestrator is failed, SubOrchestrator cannot be reentered by the following error. 

```
orchestration-processor: failed to complete work item: orchestration instance already exists
github.com/microsoft/durabletask-go/backend.(*worker).processWorkItem
        /Users/youngbu.park/go/pkg/mod/github.com/microsoft/durabletask-go@v0.6.1-0.20250524005013-f1543590a4fb/backend/worker.go:244
```

postgres implementation doesn't have WithOrchestrationIdReusePolicy option while sqlite backend has [this id reuse policy](https://github.com/microsoft/durabletask-go/blob/f1543590a4fbc9fddbef0432b9552f1da69bcfa6/backend/sqlite/sqlite.go#L339-L342). After adding this, SubOrchestrator works as expected.

Fix #105