### PR TITLE
chore: remove deprecated github.com/golang/protobuf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.23.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3
-	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/marusama/semaphore/v2 v2.5.0
@@ -25,6 +24,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/internal/protos/orchestrator_service.pb.go
+++ b/internal/protos/orchestrator_service.pb.go
@@ -10,10 +10,10 @@
 package protos
 
 import (
-	duration "github.com/golang/protobuf/ptypes/duration"
-	empty "github.com/golang/protobuf/ptypes/empty"
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
+	duration "google.golang.org/protobuf/types/known/durationpb"
+	empty "google.golang.org/protobuf/types/known/emptypb"
+	timestamp "google.golang.org/protobuf/types/known/timestamppb"
+	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"

--- a/internal/protos/orchestrator_service_grpc.pb.go
+++ b/internal/protos/orchestrator_service_grpc.pb.go
@@ -11,7 +11,7 @@ package protos
 
 import (
 	context "context"
-	empty "github.com/golang/protobuf/ptypes/empty"
+	empty "google.golang.org/protobuf/types/known/emptypb"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
Migrate generated proto imports from deprecated github.com/golang/protobuf to the maintained google.golang.org/protobuf well-known types:
- ptypes/duration -> types/known/durationpb
- ptypes/empty -> types/known/emptypb
- ptypes/timestamp -> types/known/timestamppb
- ptypes/wrappers -> types/known/wrapperspb

The deprecated package remains as an indirect dep via grpc; it will be removed when grpc updates its own imports.