### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/backend/client.go
+++ b/backend/client.go
@@ -16,7 +16,7 @@ import (
 )
 
 type TaskHubClient interface {
-	ScheduleNewOrchestration(ctx context.Context, orchestrator interface{}, opts ...api.NewOrchestrationOptions) (api.InstanceID, error)
+	ScheduleNewOrchestration(ctx context.Context, orchestrator any, opts ...api.NewOrchestrationOptions) (api.InstanceID, error)
 	FetchOrchestrationMetadata(ctx context.Context, id api.InstanceID) (*api.OrchestrationMetadata, error)
 	WaitForOrchestrationStart(ctx context.Context, id api.InstanceID) (*api.OrchestrationMetadata, error)
 	WaitForOrchestrationCompletion(ctx context.Context, id api.InstanceID) (*api.OrchestrationMetadata, error)
@@ -37,7 +37,7 @@ func NewTaskHubClient(be Backend) TaskHubClient {
 	}
 }
 
-func (c *backendClient) ScheduleNewOrchestration(ctx context.Context, orchestrator interface{}, opts ...api.NewOrchestrationOptions) (api.InstanceID, error) {
+func (c *backendClient) ScheduleNewOrchestration(ctx context.Context, orchestrator any, opts ...api.NewOrchestrationOptions) (api.InstanceID, error) {
 	name := helpers.GetTaskFunctionName(orchestrator)
 	req := &protos.CreateInstanceRequest{Name: name}
 	for _, configure := range opts {

--- a/backend/postgres/postgres.go
+++ b/backend/postgres/postgres.go
@@ -207,7 +207,7 @@ func (be *postgresBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi
 	var sqlSB strings.Builder
 	sqlSB.WriteString("UPDATE Instances SET ")
 
-	sqlUpdateArgs := make([]interface{}, 0, 10)
+	sqlUpdateArgs := make([]any, 0, 10)
 	isCreated := false
 	isCompleted := false
 
@@ -289,7 +289,7 @@ func (be *postgresBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi
 		}
 		query := builder.String()
 
-		args := make([]interface{}, 0, newHistoryCount*3)
+		args := make([]any, 0, newHistoryCount*3)
 		nextSequenceNumber := len(wi.State.OldEvents())
 		for _, e := range wi.State.NewEvents() {
 			eventPayload, err := backend.MarshalHistoryEvent(e)
@@ -320,7 +320,7 @@ func (be *postgresBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi
 		}
 		insertSql := builder.String()
 
-		sqlInsertArgs := make([]interface{}, 0, newActivityCount*2)
+		sqlInsertArgs := make([]any, 0, newActivityCount*2)
 		for _, e := range wi.State.PendingTasks() {
 			eventPayload, err := backend.MarshalHistoryEvent(e)
 			if err != nil {
@@ -349,7 +349,7 @@ func (be *postgresBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi
 		}
 		insertSql := builder.String()
 
-		sqlInsertArgs := make([]interface{}, 0, newEventCount*3)
+		sqlInsertArgs := make([]any, 0, newEventCount*3)
 		for _, e := range wi.State.PendingTimers() {
 			eventPayload, err := backend.MarshalHistoryEvent(e)
 			if err != nil {

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -203,7 +203,7 @@ func (be *sqliteBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi *
 	var sqlSB strings.Builder
 	sqlSB.WriteString("UPDATE Instances SET ")
 
-	sqlUpdateArgs := make([]interface{}, 0, 10)
+	sqlUpdateArgs := make([]any, 0, 10)
 	isCreated := false
 	isCompleted := false
 
@@ -273,7 +273,7 @@ func (be *sqliteBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi *
 		query := "INSERT INTO History ([InstanceID], [SequenceNumber], [EventPayload]) VALUES (?, ?, ?)" +
 			strings.Repeat(", (?, ?, ?)", newHistoryCount-1)
 
-		args := make([]interface{}, 0, newHistoryCount*3)
+		args := make([]any, 0, newHistoryCount*3)
 		nextSequenceNumber := len(wi.State.OldEvents())
 		for _, e := range wi.State.NewEvents() {
 			eventPayload, err := backend.MarshalHistoryEvent(e)
@@ -297,7 +297,7 @@ func (be *sqliteBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi *
 		insertSql := "INSERT INTO NewTasks ([InstanceID], [EventPayload]) VALUES (?, ?)" +
 			strings.Repeat(", (?, ?)", newActivityCount-1)
 
-		sqlInsertArgs := make([]interface{}, 0, newActivityCount*2)
+		sqlInsertArgs := make([]any, 0, newActivityCount*2)
 		for _, e := range wi.State.PendingTasks() {
 			eventPayload, err := backend.MarshalHistoryEvent(e)
 			if err != nil {
@@ -319,7 +319,7 @@ func (be *sqliteBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi *
 		insertSql := "INSERT INTO NewEvents ([InstanceID], [EventPayload], [VisibleTime]) VALUES (?, ?, ?)" +
 			strings.Repeat(", (?, ?, ?)", newEventCount-1)
 
-		sqlInsertArgs := make([]interface{}, 0, newEventCount*3)
+		sqlInsertArgs := make([]any, 0, newEventCount*3)
 		for _, e := range wi.State.PendingTimers() {
 			eventPayload, err := backend.MarshalHistoryEvent(e)
 			if err != nil {

--- a/backend/workitem.go
+++ b/backend/workitem.go
@@ -21,7 +21,7 @@ type OrchestrationWorkItem struct {
 	LockedBy   string
 	RetryCount int32
 	State      *OrchestrationRuntimeState
-	Properties map[string]interface{}
+	Properties map[string]any
 }
 
 // String implements core.WorkItem and fmt.Stringer
@@ -51,7 +51,7 @@ type ActivityWorkItem struct {
 	NewEvent       *HistoryEvent
 	Result         *HistoryEvent
 	LockedBy       string
-	Properties     map[string]interface{}
+	Properties     map[string]any
 }
 
 // String implements core.WorkItem and fmt.Stringer

--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -243,7 +243,7 @@ func (octx *OrchestrationContext) GetInput(v any) error {
 // CallActivity schedules an asynchronous invocation of an activity function. The [activity]
 // parameter can be either the name of an activity as a string or can be a pointer to the function
 // that implements the activity, in which case the name is obtained via reflection.
-func (ctx *OrchestrationContext) CallActivity(activity interface{}, opts ...callActivityOption) Task {
+func (ctx *OrchestrationContext) CallActivity(activity any, opts ...callActivityOption) Task {
 	options := new(callActivityOptions)
 	for _, configure := range opts {
 		if err := configure(options); err != nil {
@@ -262,7 +262,7 @@ func (ctx *OrchestrationContext) CallActivity(activity interface{}, opts ...call
 	return ctx.internalScheduleActivity(activity, options)
 }
 
-func (ctx *OrchestrationContext) internalScheduleActivity(activity interface{}, options *callActivityOptions) Task {
+func (ctx *OrchestrationContext) internalScheduleActivity(activity any, options *callActivityOptions) Task {
 	scheduleTaskAction := helpers.NewScheduleTaskAction(
 		ctx.getNextSequenceNumber(),
 		helpers.GetTaskFunctionName(activity),
@@ -275,7 +275,7 @@ func (ctx *OrchestrationContext) internalScheduleActivity(activity interface{}, 
 	return task
 }
 
-func (ctx *OrchestrationContext) CallSubOrchestrator(orchestrator interface{}, opts ...subOrchestratorOption) Task {
+func (ctx *OrchestrationContext) CallSubOrchestrator(orchestrator any, opts ...subOrchestratorOption) Task {
 	options := new(callSubOrchestratorOptions)
 	for _, configure := range opts {
 		if err := configure(options); err != nil {
@@ -294,7 +294,7 @@ func (ctx *OrchestrationContext) CallSubOrchestrator(orchestrator interface{}, o
 	return ctx.internalCallSubOrchestrator(orchestrator, options)
 }
 
-func (ctx *OrchestrationContext) internalCallSubOrchestrator(orchestrator interface{}, options *callSubOrchestratorOptions) Task {
+func (ctx *OrchestrationContext) internalCallSubOrchestrator(orchestrator any, options *callSubOrchestratorOptions) Task {
 	createSubOrchestrationAction := helpers.NewCreateSubOrchestrationAction(
 		ctx.getNextSequenceNumber(),
 		helpers.GetTaskFunctionName(orchestrator),


### PR DESCRIPTION
Replace all non-generated interface{} occurrences with the any type alias introduced in Go 1.18:
- backend/client.go: TaskHubClient interface and implementation
- task/orchestrator.go: CallActivity, CallSubOrchestrator signatures
- backend/workitem.go: Properties maps
- backend/sqlite/sqlite.go: SQL argument slices
- backend/postgres/postgres.go: SQL argument slices

Generated files (protos, mocks) are left unchanged as they will be updated when regenerated.