### PR TITLE
refactor: standardize error handling with sentinel errors

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -17,6 +17,10 @@ var (
 	ErrNotInitialized        = errors.New("backend not initialized")
 	ErrWorkItemLockLost      = errors.New("lock on work-item was lost")
 	ErrBackendAlreadyStarted = errors.New("backend is already started")
+	ErrOperationAborted      = errors.New("operation aborted")
+	ErrNilHistoryEvent       = errors.New("HistoryEvent must be non-nil")
+	ErrNilEventTimestamp     = errors.New("HistoryEvent must have a non-nil timestamp")
+	ErrNotExecutionStarted   = errors.New("HistoryEvent must be an ExecutionStartedEvent")
 )
 
 type (

--- a/backend/executor.go
+++ b/backend/executor.go
@@ -131,7 +131,7 @@ func (executor *grpcExecutor) ExecuteOrchestrator(ctx context.Context, iid api.I
 	case <-result.complete:
 		executor.logger.Debugf("%s: orchestrator got result", iid)
 		if result.Response == nil {
-			return nil, errors.New("operation aborted")
+			return nil, ErrOperationAborted
 		}
 	}
 
@@ -174,7 +174,7 @@ func (executor *grpcExecutor) ExecuteActivity(ctx context.Context, iid api.Insta
 	case <-result.complete:
 		executor.logger.Debugf("%s: activity got result", key)
 		if result.response == nil {
-			return nil, errors.New("operation aborted")
+			return nil, ErrOperationAborted
 		}
 	}
 
@@ -359,12 +359,12 @@ func getActivityExecutionKey(iid string, taskID int32) string {
 
 // CreateTaskHub implements protos.TaskHubSidecarServiceServer
 func (grpcExecutor) CreateTaskHub(context.Context, *protos.CreateTaskHubRequest) (*protos.CreateTaskHubResponse, error) {
-	return nil, errors.New("unimplemented")
+	return nil, status.Error(codes.Unimplemented, "CreateTaskHub is not implemented")
 }
 
 // DeleteTaskHub implements protos.TaskHubSidecarServiceServer
 func (grpcExecutor) DeleteTaskHub(context.Context, *protos.DeleteTaskHubRequest) (*protos.DeleteTaskHubResponse, error) {
-	return nil, errors.New("unimplemented")
+	return nil, status.Error(codes.Unimplemented, "DeleteTaskHub is not implemented")
 }
 
 // GetInstance implements protos.TaskHubSidecarServiceServer
@@ -387,7 +387,7 @@ func (g *grpcExecutor) GetInstance(ctx context.Context, req *protos.GetInstanceR
 // PurgeInstances implements protos.TaskHubSidecarServiceServer
 func (g *grpcExecutor) PurgeInstances(ctx context.Context, req *protos.PurgeInstancesRequest) (*protos.PurgeInstancesResponse, error) {
 	if req.GetPurgeInstanceFilter() != nil {
-		return nil, errors.New("multi-instance purge is not unimplemented")
+		return nil, status.Error(codes.Unimplemented, "multi-instance purge is not yet implemented")
 	}
 	count, err := purgeOrchestrationState(ctx, g.backend, api.InstanceID(req.GetInstanceId()), req.Recursive)
 	resp := &protos.PurgeInstancesResponse{DeletedInstanceCount: int32(count)}
@@ -399,7 +399,7 @@ func (g *grpcExecutor) PurgeInstances(ctx context.Context, req *protos.PurgeInst
 
 // QueryInstances implements protos.TaskHubSidecarServiceServer
 func (grpcExecutor) QueryInstances(context.Context, *protos.QueryInstancesRequest) (*protos.QueryInstancesResponse, error) {
-	return nil, errors.New("unimplemented")
+	return nil, status.Error(codes.Unimplemented, "QueryInstances is not implemented")
 }
 
 // RaiseEvent implements protos.TaskHubSidecarServiceServer

--- a/backend/postgres/postgres.go
+++ b/backend/postgres/postgres.go
@@ -466,14 +466,14 @@ func (be *postgresBackend) CreateOrchestrationInstance(ctx context.Context, e *b
 
 func (be *postgresBackend) createOrchestrationInstanceInternal(ctx context.Context, e *backend.HistoryEvent, tx pgx.Tx, opts ...backend.OrchestrationIdReusePolicyOptions) (string, error) {
 	if e == nil {
-		return "", errors.New("HistoryEvent must be non-nil")
+		return "", backend.ErrNilHistoryEvent
 	} else if e.Timestamp == nil {
-		return "", errors.New("HistoryEvent must have a non-nil timestamp")
+		return "", backend.ErrNilEventTimestamp
 	}
 
 	startEvent := e.GetExecutionStarted()
 	if startEvent == nil {
-		return "", errors.New("HistoryEvent must be an ExecutionStartedEvent")
+		return "", backend.ErrNotExecutionStarted
 	}
 	instanceID := startEvent.OrchestrationInstance.InstanceId
 
@@ -632,9 +632,9 @@ func (be *postgresBackend) cleanupOrchestrationStateInternal(ctx context.Context
 
 func (be *postgresBackend) AddNewOrchestrationEvent(ctx context.Context, iid api.InstanceID, e *backend.HistoryEvent) error {
 	if e == nil {
-		return errors.New("HistoryEvent must be non-nil")
+		return backend.ErrNilHistoryEvent
 	} else if e.Timestamp == nil {
-		return errors.New("HistoryEvent must have a non-nil timestamp")
+		return backend.ErrNilEventTimestamp
 	}
 
 	eventPayload, err := backend.MarshalHistoryEvent(e)

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -436,14 +436,14 @@ func (be *sqliteBackend) CreateOrchestrationInstance(ctx context.Context, e *bac
 
 func (be *sqliteBackend) createOrchestrationInstanceInternal(ctx context.Context, e *backend.HistoryEvent, tx *sql.Tx, opts ...backend.OrchestrationIdReusePolicyOptions) (string, error) {
 	if e == nil {
-		return "", errors.New("HistoryEvent must be non-nil")
+		return "", backend.ErrNilHistoryEvent
 	} else if e.Timestamp == nil {
-		return "", errors.New("HistoryEvent must have a non-nil timestamp")
+		return "", backend.ErrNilEventTimestamp
 	}
 
 	startEvent := e.GetExecutionStarted()
 	if startEvent == nil {
-		return "", errors.New("HistoryEvent must be an ExecutionStartedEvent")
+		return "", backend.ErrNotExecutionStarted
 	}
 	instanceID := startEvent.OrchestrationInstance.InstanceId
 
@@ -606,9 +606,9 @@ func (be *sqliteBackend) cleanupOrchestrationStateInternal(ctx context.Context, 
 
 func (be *sqliteBackend) AddNewOrchestrationEvent(ctx context.Context, iid api.InstanceID, e *backend.HistoryEvent) error {
 	if e == nil {
-		return errors.New("HistoryEvent must be non-nil")
+		return backend.ErrNilHistoryEvent
 	} else if e.Timestamp == nil {
-		return errors.New("HistoryEvent must have a non-nil timestamp")
+		return backend.ErrNilEventTimestamp
 	}
 
 	eventPayload, err := backend.MarshalHistoryEvent(e)


### PR DESCRIPTION
- Add ErrOperationAborted, ErrNilHistoryEvent, ErrNilEventTimestamp, ErrNotExecutionStarted sentinel errors to backend package
- Replace bare errors.New() calls with sentinel errors in sqlite and postgres backends for consistent error checking via errors.Is()
- Replace bare errors.New("unimplemented") in gRPC executor with proper status.Error(codes.Unimplemented, ...) for gRPC compliance
- Fix typo: "multi-instance purge is not unimplemented" ->
  "multi-instance purge is not yet implemented"