### PR TITLE
Add deterministic NewGuid() to OrchestrationContext

### DIFF
--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/microsoft/durabletask-go/api"
@@ -16,6 +17,14 @@ import (
 	"github.com/microsoft/durabletask-go/internal/helpers"
 	"github.com/microsoft/durabletask-go/internal/protos"
 )
+
+// deterministicGuidNamespace is the namespace UUID used for deterministic GUID generation (UUID v5).
+// This matches the namespace used by the .NET Durable Task SDK.
+var deterministicGuidNamespace = uuid.MustParse("9e952958-5e33-4daf-827f-2fa12937b875")
+
+// dotnetDateTimeFormat matches .NET's DateTime.ToString("o") for UTC values.
+// Always produces exactly 7 fractional digits (100-nanosecond/tick precision) with trailing Z.
+const dotnetDateTimeFormat = "2006-01-02T15:04:05.0000000Z"
 
 // Orchestrator is the functional interface for orchestrator functions.
 type Orchestrator func(ctx *OrchestrationContext) (any, error)
@@ -44,6 +53,8 @@ type OrchestrationContext struct {
 	bufferedExternalEvents     map[string]*list.List
 	pendingExternalEventTasks  map[string]*list.List
 	saveBufferedExternalEvents bool
+
+	newGuidCounter int
 }
 
 // callSubOrchestratorOptions is a struct that holds the options for the CallSubOrchestrator orchestrator method.
@@ -435,6 +446,19 @@ func (ctx *OrchestrationContext) ContinueAsNew(newInput any, options ...Continue
 	for _, option := range options {
 		option(ctx)
 	}
+}
+
+// NewGuid generates a deterministic UUID that is safe to use in orchestrator functions.
+// The generated UUID is based on the orchestration instance ID, the current replay-safe timestamp,
+// and an internal counter, ensuring the same sequence of UUIDs is produced on each replay.
+// This uses UUID v5 (SHA-1) per RFC 4122, matching the algorithm used by the .NET Durable Task SDK.
+func (ctx *OrchestrationContext) NewGuid() uuid.UUID {
+	// Truncate to 100-nanosecond (tick) precision to match .NET DateTime behavior,
+	// then format with exactly 7 fractional digits to match .NET's ToString("o").
+	truncatedTime := ctx.CurrentTimeUtc.Truncate(100 * time.Nanosecond)
+	name := fmt.Sprintf("%s_%s_%d", ctx.ID, truncatedTime.Format(dotnetDateTimeFormat), ctx.newGuidCounter)
+	ctx.newGuidCounter++
+	return uuid.NewSHA1(deterministicGuidNamespace, []byte(name))
 }
 
 func (ctx *OrchestrationContext) onExecutionStarted(es *protos.ExecutionStartedEvent) error {

--- a/task/orchestrator_test.go
+++ b/task/orchestrator_test.go
@@ -3,6 +3,9 @@ package task
 import (
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/microsoft/durabletask-go/api"
 )
 
 func Test_computeNextDelay(t *testing.T) {
@@ -129,5 +132,184 @@ func Test_computeNextDelay(t *testing.T) {
 				t.Errorf("computeNextDelay() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_NewGuid_Deterministic(t *testing.T) {
+	// Two contexts with the same ID and time should produce the same GUIDs
+	makeCtx := func() *OrchestrationContext {
+		return &OrchestrationContext{
+			ID:             api.InstanceID("test-instance-123"),
+			CurrentTimeUtc: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+		}
+	}
+
+	ctx1 := makeCtx()
+	ctx2 := makeCtx()
+
+	guid1a := ctx1.NewGuid()
+	guid1b := ctx1.NewGuid()
+	guid2a := ctx2.NewGuid()
+	guid2b := ctx2.NewGuid()
+
+	// Same sequence from same inputs should produce same GUIDs
+	if guid1a != guid2a {
+		t.Errorf("first GUID should be deterministic: %s != %s", guid1a, guid2a)
+	}
+	if guid1b != guid2b {
+		t.Errorf("second GUID should be deterministic: %s != %s", guid1b, guid2b)
+	}
+}
+
+func Test_NewGuid_Unique(t *testing.T) {
+	ctx := &OrchestrationContext{
+		ID:             api.InstanceID("test-instance"),
+		CurrentTimeUtc: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+	}
+
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		guid := ctx.NewGuid().String()
+		if seen[guid] {
+			t.Fatalf("duplicate GUID at iteration %d: %s", i, guid)
+		}
+		seen[guid] = true
+	}
+}
+
+func Test_NewGuid_DifferentInstances(t *testing.T) {
+	ts := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	ctx1 := &OrchestrationContext{
+		ID:             api.InstanceID("instance-A"),
+		CurrentTimeUtc: ts,
+	}
+	ctx2 := &OrchestrationContext{
+		ID:             api.InstanceID("instance-B"),
+		CurrentTimeUtc: ts,
+	}
+
+	guid1 := ctx1.NewGuid()
+	guid2 := ctx2.NewGuid()
+	if guid1 == guid2 {
+		t.Errorf("GUIDs from different instances should differ: %s == %s", guid1, guid2)
+	}
+}
+
+func Test_NewGuid_DifferentTimes(t *testing.T) {
+	ctx1 := &OrchestrationContext{
+		ID:             api.InstanceID("same-instance"),
+		CurrentTimeUtc: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+	}
+	ctx2 := &OrchestrationContext{
+		ID:             api.InstanceID("same-instance"),
+		CurrentTimeUtc: time.Date(2025, 1, 15, 10, 31, 0, 0, time.UTC),
+	}
+
+	guid1 := ctx1.NewGuid()
+	guid2 := ctx2.NewGuid()
+	if guid1 == guid2 {
+		t.Errorf("GUIDs from different timestamps should differ: %s == %s", guid1, guid2)
+	}
+}
+
+func Test_NewGuid_NanosecondTruncation(t *testing.T) {
+	// Two timestamps differing only in the last 2 nanosecond digits (sub-100ns)
+	// should produce the SAME GUID, since .NET truncates to 100ns (tick) precision.
+	ctx1 := &OrchestrationContext{
+		ID:             api.InstanceID("truncation-test"),
+		CurrentTimeUtc: time.Date(2025, 1, 15, 10, 30, 45, 123456700, time.UTC),
+	}
+	ctx2 := &OrchestrationContext{
+		ID:             api.InstanceID("truncation-test"),
+		CurrentTimeUtc: time.Date(2025, 1, 15, 10, 30, 45, 123456789, time.UTC),
+	}
+
+	guid1 := ctx1.NewGuid()
+	guid2 := ctx2.NewGuid()
+	if guid1 != guid2 {
+		t.Errorf("sub-100ns differences should be truncated: %s != %s", guid1, guid2)
+	}
+}
+
+func Test_NewGuid_TimestampFormat(t *testing.T) {
+	// Verify the internal timestamp format matches .NET's DateTime.ToString("o")
+	// .NET always produces exactly 7 fractional digits for UTC DateTimes
+	ts := time.Date(2025, 1, 15, 10, 30, 45, 123456700, time.UTC)
+	truncated := ts.Truncate(100 * time.Nanosecond)
+	formatted := truncated.Format(dotnetDateTimeFormat)
+	expected := "2025-01-15T10:30:45.1234567Z"
+	if formatted != expected {
+		t.Errorf("timestamp format mismatch: got %q, want %q", formatted, expected)
+	}
+
+	// Zero nanoseconds should still produce 7 fractional digits
+	tsZero := time.Date(2025, 1, 15, 10, 30, 45, 0, time.UTC)
+	formattedZero := tsZero.Format(dotnetDateTimeFormat)
+	expectedZero := "2025-01-15T10:30:45.0000000Z"
+	if formattedZero != expectedZero {
+		t.Errorf("zero nanos format mismatch: got %q, want %q", formattedZero, expectedZero)
+	}
+}
+
+func Test_NewGuid_GoldenValues(t *testing.T) {
+	// Hardcoded expected UUIDs for known inputs. If the algorithm changes,
+	// this test will fail — which is intentional, because changing the output
+	// would break replay determinism for in-flight orchestrations.
+	ctx := &OrchestrationContext{
+		ID:             api.InstanceID("test-instance-123"),
+		CurrentTimeUtc: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+	}
+
+	guid0 := ctx.NewGuid()
+	guid1 := ctx.NewGuid()
+	guid2 := ctx.NewGuid()
+
+	if got := guid0.String(); got != "9521ac35-a19d-52bb-84e8-e0977ae0dfe0" {
+		t.Errorf("guid[0] golden mismatch: got %s", got)
+	}
+	if got := guid1.String(); got != "0f10c9ff-99eb-5ec4-bd1d-8b29b5fcefbe" {
+		t.Errorf("guid[1] golden mismatch: got %s", got)
+	}
+	if got := guid2.String(); got != "9668a7c0-9fdd-5030-ac13-f9444f086ab9" {
+		t.Errorf("guid[2] golden mismatch: got %s", got)
+	}
+}
+
+func Test_NewGuid_UUIDv5Properties(t *testing.T) {
+	ctx := &OrchestrationContext{
+		ID:             api.InstanceID("version-check"),
+		CurrentTimeUtc: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	for i := 0; i < 10; i++ {
+		guid := ctx.NewGuid()
+		if guid.Version() != 5 {
+			t.Errorf("call %d: expected UUID version 5, got %d", i, guid.Version())
+		}
+		if guid.Variant() != uuid.RFC4122 {
+			t.Errorf("call %d: expected RFC4122 variant, got %s", i, guid.Variant())
+		}
+	}
+}
+
+func Test_NewGuid_CounterResetOnNewContext(t *testing.T) {
+	// Simulates what happens during replay: a new context is created,
+	// counter starts at 0, producing the same GUID sequence.
+	makeAndGenerate := func() [3]uuid.UUID {
+		ctx := &OrchestrationContext{
+			ID:             api.InstanceID("replay-test"),
+			CurrentTimeUtc: time.Date(2025, 3, 1, 12, 0, 0, 0, time.UTC),
+		}
+		return [3]uuid.UUID{ctx.NewGuid(), ctx.NewGuid(), ctx.NewGuid()}
+	}
+
+	run1 := makeAndGenerate()
+	run2 := makeAndGenerate()
+
+	for i := range run1 {
+		if run1[i] != run2[i] {
+			t.Errorf("guid[%d] differs across fresh contexts: %s != %s", i, run1[i], run2[i])
+		}
 	}
 }

--- a/tests/orchestrations_test.go
+++ b/tests/orchestrations_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -1474,6 +1475,76 @@ func Test_SingleActivity_ReuseInstanceIDError(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "orchestration instance already exists")
 	}
+}
+
+func Test_NewGuid(t *testing.T) {
+	// Registration
+	r := task.NewTaskRegistry()
+	require.NoError(t, r.AddOrchestratorN("NewGuidOrch", func(ctx *task.OrchestrationContext) (any, error) {
+		// Generate two GUIDs before any await - they should be unique
+		guid1 := ctx.NewGuid()
+		guid2 := ctx.NewGuid()
+		if guid1 == guid2 {
+			return nil, fmt.Errorf("consecutive GUIDs should be unique: %s == %s", guid1, guid2)
+		}
+
+		// Pass guid2 through an activity (which forces a replay) and verify it stays the same
+		var echoed string
+		if err := ctx.CallActivity("EchoGuid", task.WithActivityInput(guid2.String())).Await(&echoed); err != nil {
+			return nil, err
+		}
+		if guid2.String() != echoed {
+			return nil, fmt.Errorf("GUID changed after replay: %s != %s", guid2, echoed)
+		}
+
+		// Generate another GUID after the await - should be unique from prior ones
+		guid3 := ctx.NewGuid()
+		if guid3 == guid1 || guid3 == guid2 {
+			return nil, fmt.Errorf("post-await GUID collided with prior GUIDs")
+		}
+
+		// Verify determinism after another replay
+		var echoed2 string
+		if err := ctx.CallActivity("EchoGuid", task.WithActivityInput(guid3.String())).Await(&echoed2); err != nil {
+			return nil, err
+		}
+		if guid3.String() != echoed2 {
+			return nil, fmt.Errorf("post-await GUID changed after replay: %s != %s", guid3, echoed2)
+		}
+
+		return []string{guid1.String(), guid2.String(), guid3.String()}, nil
+	}))
+	require.NoError(t, r.AddActivityN("EchoGuid", func(ctx task.ActivityContext) (any, error) {
+		var input string
+		if err := ctx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		return input, nil
+	}))
+
+	// Initialization
+	ctx := context.Background()
+	client, worker := initTaskHubWorker(ctx, r)
+	defer func() {
+		if err := worker.Shutdown(ctx); err != nil {
+			t.Logf("shutdown: %v", err)
+		}
+	}()
+
+	// Run the orchestration
+	id, err := client.ScheduleNewOrchestration(ctx, "NewGuidOrch")
+	require.NoError(t, err)
+	metadata, err := client.WaitForOrchestrationCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, metadata.RuntimeStatus)
+
+	// Verify we got 3 distinct GUIDs back
+	var guids []string
+	require.NoError(t, json.Unmarshal([]byte(metadata.SerializedOutput), &guids))
+	assert.Len(t, guids, 3)
+	assert.NotEqual(t, guids[0], guids[1])
+	assert.NotEqual(t, guids[1], guids[2])
+	assert.NotEqual(t, guids[0], guids[2])
 }
 
 func initTaskHubWorker(ctx context.Context, r *task.TaskRegistry, opts ...backend.NewTaskWorkerOptions) (backend.TaskHubClient, backend.TaskHubWorker) {


### PR DESCRIPTION
## Summary

Adds a replay-safe, deterministic UUID generation method to `OrchestrationContext`, closing the gap with the .NET Durable Task SDK.

## Algorithm

Uses **UUID v5** (SHA-1, RFC 4122) with the same namespace (`9e952958-5e33-4daf-827f-2fa12937b875`) and name format (`{instanceId}_{timestamp}_{counter}`) as the .NET implementation.

### Cross-SDK alignment details
- Timestamp formatted with exactly **7 fractional digits** to match .NET `DateTime.ToString("o")`
- Nanoseconds **truncated to 100ns** (tick) precision to match .NET `DateTime` behavior
- Counter starts at 0 per context, incremented after each call
- Produces **identical UUIDs** to the .NET SDK for the same inputs

## Usage

```go
func MyOrchestrator(ctx *task.OrchestrationContext) (any, error) {
    id := ctx.NewGuid() // deterministic, replay-safe UUID
    // use id as correlation ID, idempotency key, etc.
}
```

## Changes

| File | Change |
|---|---|
| `task/orchestrator.go` | `uuid` import, namespace constant, format constant, `newGuidCounter` field, `NewGuid()` method |
| `task/orchestrator_test.go` | 9 unit tests (determinism, uniqueness, golden values, UUID v5 compliance, .NET format alignment, nanosecond truncation, counter reset) |
| `tests/orchestrations_test.go` | 1 integration test (replay determinism through activity calls) |

## Test Coverage

| Test | Verifies |
|---|---|
| `Deterministic` | Same inputs → same GUIDs |
| `Unique` | 100 consecutive calls all unique |
| `DifferentInstances` | Instance ID isolation |
| `DifferentTimes` | Timestamp isolation |
| `NanosecondTruncation` | Sub-100ns truncated (.NET parity) |
| `TimestampFormat` | 7 fractional digits + Z |
| `GoldenValues` | Hardcoded regression test |
| `UUIDv5Properties` | Version=5, Variant=RFC4122 |
| `CounterResetOnNewContext` | Fresh context = counter at 0 |
| Integration `Test_NewGuid` | End-to-end replay with activities |

## Related

Closes gap identified in cross-SDK alignment analysis: .NET has `TaskOrchestrationContext.NewGuid()` but Go had no equivalent, forcing users to use non-deterministic `uuid.New()` which breaks replay.
