### PR TITLE
backend: don't wedge on duplicate sub-orch create; use ActivityLockTi…

### DIFF
--- a/backend/postgres/postgres.go
+++ b/backend/postgres/postgres.go
@@ -370,7 +370,15 @@ func (be *postgresBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi
 					OperationStatus: []protos.OrchestrationStatus{protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED},
 					Action:          api.REUSE_ID_ACTION_TERMINATE,
 				})); err != nil {
-					if errors.Is(err, backend.ErrDuplicateEvent) {
+					// A target instance that already exists (in a status the
+					// reuse policy does not reclaim) must not fail the whole
+					// work item — drop the duplicate creation instead of
+					// poison-looping on redelivery. handleInstanceExists
+					// surfaces this as api.ErrDuplicateInstance /
+					// api.ErrIgnoreInstance.
+					if errors.Is(err, backend.ErrDuplicateEvent) ||
+						errors.Is(err, api.ErrDuplicateInstance) ||
+						errors.Is(err, api.ErrIgnoreInstance) {
 						be.logger.Warnf(
 							"%v: dropping sub-orchestration creation event because an instance with the target ID (%v) already exists.",
 							wi.InstanceID,
@@ -885,7 +893,11 @@ func (be *postgresBackend) GetActivityWorkItem(ctx context.Context) (*backend.Ac
 	}
 
 	now := time.Now().UTC()
-	newLockExpiration := now.Add(be.options.OrchestrationLockTimeout)
+	// Activity work-items use the ActivityLockTimeout (activities can run far
+	// longer than orchestration turns, e.g. CloudStack cluster create) — not
+	// the orchestration timeout. Locks are not renewed, so this must exceed
+	// the longest activity.
+	newLockExpiration := now.Add(be.options.ActivityLockTimeout)
 
 	row := be.db.QueryRow(
 		ctx,

--- a/backend/sqlite/sqlite.go
+++ b/backend/sqlite/sqlite.go
@@ -339,7 +339,15 @@ func (be *sqliteBackend) CompleteOrchestrationWorkItem(ctx context.Context, wi *
 					OperationStatus: []protos.OrchestrationStatus{protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED},
 					Action:          api.REUSE_ID_ACTION_TERMINATE,
 				})); err != nil {
-					if errors.Is(err, backend.ErrDuplicateEvent) {
+					// A target instance that already exists (in a status the
+					// reuse policy does not reclaim) must not fail the whole
+					// work item — drop the duplicate creation instead of
+					// poison-looping on redelivery. handleInstanceExists
+					// surfaces this as api.ErrDuplicateInstance /
+					// api.ErrIgnoreInstance.
+					if errors.Is(err, backend.ErrDuplicateEvent) ||
+						errors.Is(err, api.ErrDuplicateInstance) ||
+						errors.Is(err, api.ErrIgnoreInstance) {
 						be.logger.Warnf(
 							"%v: dropping sub-orchestration creation event because an instance with the target ID (%v) already exists.",
 							wi.InstanceID,
@@ -853,7 +861,10 @@ func (be *sqliteBackend) GetActivityWorkItem(ctx context.Context) (*backend.Acti
 	}
 
 	now := time.Now().UTC()
-	newLockExpiration := now.Add(be.options.OrchestrationLockTimeout)
+	// Activity work-items use the ActivityLockTimeout (activities can run far
+	// longer than orchestration turns) — not the orchestration timeout. Locks
+	// are not renewed, so this must exceed the longest activity.
+	newLockExpiration := now.Add(be.options.ActivityLockTimeout)
 
 	row := be.db.QueryRowContext(
 		ctx,


### PR DESCRIPTION
Two fixes to the postgres and sqlite backends:

1. CompleteOrchestrationWorkItem drops a sub-orchestration creation event when the target instance already exists in a status the id-reuse policy does not reclaim. createOrchestrationInstanceInternal surfaces this as api.ErrDuplicateInstance ("orchestration instance already exists") / api.ErrIgnoreInstance, but the handler only caught backend.ErrDuplicateEvent, so the error propagated and the work item never committed — the NewEvent was redelivered forever, wedging the parent orchestration RUNNING. Widen the catch to also drop ErrDuplicateInstance / ErrIgnoreInstance.

2. GetActivityWorkItem set the work-item lock expiration from OrchestrationLockTimeout instead of ActivityLockTimeout. Activities can run far longer than an orchestration turn (e.g. a cluster-create polling for ~30m) and the lock is not renewed, so a long activity dropped its lock and got redispatched. Use ActivityLockTimeout, which was previously dead config.