### PR TITLE
Add worker reconnection logging to durabletask-go

### DIFF
--- a/backend/worker.go
+++ b/backend/worker.go
@@ -47,7 +47,7 @@ type worker struct {
 	processor TaskProcessor
 	waiting   bool
 	stop      atomic.Bool
-	// consecutiveErrors tracks connection failures for reconnection logging
+	// consecutiveErrors tracks consecutive FetchWorkItem failures for recovery logging
 	consecutiveErrors atomic.Int32
 }
 

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -47,6 +47,8 @@ type worker struct {
 	processor TaskProcessor
 	waiting   bool
 	stop      atomic.Bool
+	// consecutiveErrors tracks connection failures for reconnection logging
+	consecutiveErrors atomic.Int32
 }
 
 type NewTaskWorkerOptions func(*WorkerOptions)
@@ -113,6 +115,9 @@ func (w *worker) Start(ctx context.Context) {
 			switch {
 			case ok:
 				// found a work item - reset the backoff and check for the next item
+				if w.waiting {
+					w.logger.Infof("%v: reconnected and ready to process work items", w.Name())
+				}
 				b.Reset()
 			case err != nil && errors.Is(err, ctx.Err()):
 				// there's an error and it's due to the context being canceled
@@ -174,6 +179,11 @@ func (w *worker) ProcessNext(ctx context.Context) (bool, error) {
 	wi, err := w.processor.FetchWorkItem(ctx)
 	switch {
 	case errors.Is(err, ErrNoWorkItems) || wi == nil:
+		// Check if we recovered from connection errors
+		if w.consecutiveErrors.Load() > 0 {
+			w.logger.Infof("%v: reconnected and ready to process work items", w.Name())
+			w.consecutiveErrors.Store(0)
+		}
 		if !w.waiting {
 			w.logger.Debugf("%v: waiting for new work items...", w.Name())
 			w.waiting = true
@@ -182,9 +192,16 @@ func (w *worker) ProcessNext(ctx context.Context) (bool, error) {
 	case err != nil:
 		if !errors.Is(err, ctx.Err()) {
 			w.logger.Errorf("%v: failed to fetch work item: %v", w.Name(), err)
+			// Increment error counter for connection-related errors
+			w.consecutiveErrors.Add(1)
 		}
 		return false, err
 	default:
+		// Check if we recovered from connection errors when successfully fetching work item
+		if w.consecutiveErrors.Load() > 0 {
+			w.logger.Infof("%v: reconnected and ready to process work items", w.Name())
+			w.consecutiveErrors.Store(0)
+		}
 		// process the work-item in the background
 		w.waiting = false
 		processing = true

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -115,9 +115,6 @@ func (w *worker) Start(ctx context.Context) {
 			switch {
 			case ok:
 				// found a work item - reset the backoff and check for the next item
-				if w.waiting {
-					w.logger.Infof("%v: reconnected and ready to process work items", w.Name())
-				}
 				b.Reset()
 			case err != nil && errors.Is(err, ctx.Err()):
 				// there's an error and it's due to the context being canceled

--- a/backend/worker.go
+++ b/backend/worker.go
@@ -179,7 +179,7 @@ func (w *worker) ProcessNext(ctx context.Context) (bool, error) {
 	wi, err := w.processor.FetchWorkItem(ctx)
 	switch {
 	case errors.Is(err, ErrNoWorkItems) || wi == nil:
-		// Check if we recovered from connection errors
+		// Check if we recovered from errors when no work items
 		if w.consecutiveErrors.Load() > 0 {
 			w.logger.Infof("%v: reconnected and ready to process work items", w.Name())
 			w.consecutiveErrors.Store(0)
@@ -192,12 +192,12 @@ func (w *worker) ProcessNext(ctx context.Context) (bool, error) {
 	case err != nil:
 		if !errors.Is(err, ctx.Err()) {
 			w.logger.Errorf("%v: failed to fetch work item: %v", w.Name(), err)
-			// Increment error counter for connection-related errors
+			// Increment error counter for fetch failures
 			w.consecutiveErrors.Add(1)
 		}
 		return false, err
 	default:
-		// Check if we recovered from connection errors when successfully fetching work item
+		// Check if we recovered from errors when successfully fetching work item
 		if w.consecutiveErrors.Load() > 0 {
 			w.logger.Infof("%v: reconnected and ready to process work items", w.Name())
 			w.consecutiveErrors.Store(0)


### PR DESCRIPTION
## Changes:
- Added `consecutiveErrors` counter to track connection failures
- Log "reconnected and ready to process work items" when worker recovers from connection errors
- Works for both scenarios: when there are work items to process and when there are none
- Each worker (activity-processor and orchestration-processor) logs its own reconnection status
 
## Benefits:
- Better visibility into worker health and connection status
- Easier debugging of connection issues
- Clear indication when workers successfully reconnect after failures
 
## Testing:
Tested by stopping PostgreSQL container and observing reconnection logs when connection 

## Evidence:
<img width="855" height="168" alt="image" src="https://github.com/user-attachments/assets/075893e1-4c50-4d81-97e9-0563650f356b" />
