### PR TITLE
Add engineering system metadata

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: a45bac48-a99c-4628-abbb-49725dd92796
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\DurableTask


### PR DESCRIPTION
## Summary
- add the root `es-metadata.yml` InventoryAsCode manifest
- set the accountable service to `a45bac48-a99c-4628-abbb-49725dd92796`
- retain the established Durable SDK routing to `azfunc` / `internal\DurableTask`

## Validation
- parsed the manifest as YAML and verified required values
- confirmed its structure exactly matches `microsoft/durabletask-dotnet`, `microsoft/durabletask-java`, and `microsoft/durabletask-js` after substituting the requested service owner GUID